### PR TITLE
Template features + autoinstalls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ test/lib
 test/app-build.html
 test/test.js
 test/test.js.map
+test/test-babel.js
+test/test-babel.js.map

--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,3 @@
 chomp build
-cp ~/bin/chomp.exe ~/bin/chomp2.exe
-cp ./target/Debug/chomp.exe ~/bin/chomp.exe
+cp ~/bin/chomp ~/bin/chomp2
+cp ./target/Debug/chomp ~/bin/chomp

--- a/src/templates.toml
+++ b/src/templates.toml
@@ -1,28 +1,30 @@
 ﻿version = 0.1
 [[template]]
   name = "babel"
-  definition = """({ presets = [], plugins = [], sourceMap = true }) => {
-    return [{
-      deps: [...presets.map(p => `node_modules/${p}`), ...plugins.map(p => `node_modules/${p}`), 'node_modules/@babel/core', 'node_modules/@babel/cli'],
-      run: `babel $DEP -o $TARGET${
-          sourceMap ? ' --source-maps' : ''
-        }${
-          plugins.length ? ` --plugins=${plugins.join(',')}` : ''
-        }${
-          presets.length ? ` --presets=${presets.join(',')}` : ''
-        }`
-    }, {
-      template: 'npm:install',
-      args: {
-        packages: [...presets.map(p => p.startsWith('@babel/') ? p + '@7' : p), ...plugins.map(p => p.startsWith('@babel/') ? p + '@7' : p), '@babel/core@7', '@babel/cli@7'],
-        dev: true
-      }
-    }];
-  }
+  definition = """({ autoInstall = false, presets = [], plugins = [], sourceMap = true, noBabelRc = false, configFile = null }) => [{
+    deps: [...presets.map(p => `node_modules/${p}`), ...plugins.map(p => `node_modules/${p}`), 'node_modules/@babel/core', 'node_modules/@babel/cli'],
+    run: `babel $DEP -o $TARGET${
+        sourceMap ? ' --source-maps' : ''
+      }${
+        plugins.length ? ` --plugins=${plugins.join(',')}` : ''
+      }${
+        presets.length ? ` --presets=${presets.join(',')}` : ''
+      }${
+        noBabelRc ? ' --no-babelrc' : ''
+      }${
+        configFile ? ` --config-file=${configFile}` : ''
+      }`
+  }, {
+    template: autoInstall ? 'npm:install' : 'npm:verify',
+    args: {
+      packages: [...presets.map(p => p.startsWith('@babel/') ? p + '@7' : p), ...plugins.map(p => p.startsWith('@babel/') ? p + '@7' : p), '@babel/core@7', '@babel/cli@7'],
+      dev: true
+    }
+  }];
   """
 [[template]]
   name = "jspm:generate"
-  definition = """({ generatorEnv = ['browser', 'production', 'module'], ...generateOpts }) => [{
+  definition = """({ autoInstall = false, generatorEnv = ['browser', 'production', 'module'], ...generateOpts }) => [{
     deps: ['node_modules/@jspm/generator', 'node_modules/mkdirp'],
     engine: 'node',
     run: `
@@ -44,9 +46,9 @@
       await writeFile(process.env.TARGET, outHtml);
     `
   }, {
-    template: 'npm:install',
+    template: autoInstall ? 'npm:install' : 'npm:verify',
     args: {
-      packages: ['@jspm/generator@^1.0.0-beta.21', 'mkdirp'],
+      packages: ['@jspm/generator', 'mkdirp'],
       dev: true
     }
   }]
@@ -65,11 +67,28 @@
     }),
     serial: true
   }, ...packages.map(pkg => ({
-    target: `node_modules/${pkg}`,
+    targets: packages.map(pkg => {
+      const versionIndex = pkg.indexOf('@', 1);
+      return `node_modules/${versionIndex === -1 ? pkg : pkg.slice(0, versionIndex)}`;
+    }),
     target_check: 'exists',
     deps: ['npm:init'],
-    run: `npm install ${pkg}${dev ? ' --save-dev' : ''}`
+    run: `npm install ${packages.join(' ')}${dev ? ' -D' : ''}`
   }))];
+  """
+
+# npm verify template
+# instead of installing packages, it just verifies they are present, providing an
+# error and instruction if they are not
+[[template]]
+  name = "npm:verify"
+  definition = """({ packages, dev }) => [{
+    targets: packages.map(pkg => {
+      const versionIndex = pkg.indexOf('@', 1);
+      return `node_modules/${versionIndex === -1 ? pkg : pkg.slice(0, versionIndex)}`;
+    }),
+    run: `echo "\n\\x1b[93mChomp\\x1b[0m: Some packages are missing. Please run \\x1b[1mnpm install ${packages.join(' ')}${dev ? ' -D' : ''}\\x1b[0m\n"`
+  }];
   """
 
 # npm install task
@@ -93,7 +112,7 @@
   run = "npm init -y"
 [[template]]
   name = "svelte"
-  definition = """() => [{
+  definition = """({ autoInstall = false, svelteConfig = null }) => [{
     deps: ['node_modules/svelte', 'node_modules/mkdirp'],
     engine: 'node',
     run: `
@@ -102,13 +121,18 @@
       import mkdirp from 'mkdirp';
       import { dirname } from 'path';
 
+      let config;
+      ${svelteConfig ? `
+        config = await import(${svelteConfig === true ? '"./svelte.config.js"' : svelteConfig});
+      ` : `
+        config = {
+          css: false
+        };
+      `}
+      config.filename = process.env.DEP;
+
       const source = await readFile(process.env.DEP, 'utf-8');
-      const result = compile(source, {
-        // TODO:
-        // - preprocessor support for eg TypeScript
-        filename: process.env.DEP,
-        css: false,
-      });
+      const result = compile(source, config);
 
       mkdirp.sync(dirname(process.env.TARGET));
       const cssFile = process.env.TARGET.replace(/\\.js$/, ".css");
@@ -120,7 +144,7 @@
       ];
     `
   }, {
-    template: 'npm:install',
+    template: autoInstall ? 'npm:install' : 'npm:verify',
     args: {
       packages: ['svelte@3', 'mkdirp'],
       dev: true
@@ -129,11 +153,19 @@
   """
 [[template]]
   name = "swc"
-  definition = """() => [{
+  definition = """({ autoInstall = false, configFile = null, noSwcrc, sourceMaps = true, config = {} }) => [{
     deps: ['node_modules/@swc/core', 'node_modules/@swc/cli'],
-    run: "swc $DEP -o $TARGET"
+    run: `swc $DEP -o $TARGET${
+        noSwcrc ? ' --no-swcrc' : ''
+      }${
+        configFile ? ` --config-file=${configFile}` : ''
+      }${
+        sourceMaps ? ' --source-maps' : ''
+      }${
+        Object.keys(config).length ? ' ' + Object.keys(config).map(key => `-C ${key}=${config[key]}`).join(' ') : ''
+      }`
   }, {
-    template: 'npm:install',
+    template: autoInstall ? 'npm:install' : 'npm:verify',
     args: {
       packages: ['@swc/core@1', '@swc/cli@0.1'],
       dev: true

--- a/templates/babel.toml
+++ b/templates/babel.toml
@@ -1,21 +1,23 @@
 [[template]]
   name = "babel"
-  definition = """({ presets = [], plugins = [], sourceMap = true }) => {
-    return [{
-      deps: [...presets.map(p => `node_modules/${p}`), ...plugins.map(p => `node_modules/${p}`), 'node_modules/@babel/core', 'node_modules/@babel/cli'],
-      run: `babel $DEP -o $TARGET${
-          sourceMap ? ' --source-maps' : ''
-        }${
-          plugins.length ? ` --plugins=${plugins.join(',')}` : ''
-        }${
-          presets.length ? ` --presets=${presets.join(',')}` : ''
-        }`
-    }, {
-      template: 'npm:install',
-      args: {
-        packages: [...presets.map(p => p.startsWith('@babel/') ? p + '@7' : p), ...plugins.map(p => p.startsWith('@babel/') ? p + '@7' : p), '@babel/core@7', '@babel/cli@7'],
-        dev: true
-      }
-    }];
-  }
+  definition = """({ autoInstall = false, presets = [], plugins = [], sourceMap = true, noBabelRc = false, configFile = null }) => [{
+    deps: [...presets.map(p => `node_modules/${p}`), ...plugins.map(p => `node_modules/${p}`), 'node_modules/@babel/core', 'node_modules/@babel/cli'],
+    run: `babel $DEP -o $TARGET${
+        sourceMap ? ' --source-maps' : ''
+      }${
+        plugins.length ? ` --plugins=${plugins.join(',')}` : ''
+      }${
+        presets.length ? ` --presets=${presets.join(',')}` : ''
+      }${
+        noBabelRc ? ' --no-babelrc' : ''
+      }${
+        configFile ? ` --config-file=${configFile}` : ''
+      }`
+  }, {
+    template: autoInstall ? 'npm:install' : 'npm:verify',
+    args: {
+      packages: [...presets.map(p => p.startsWith('@babel/') ? p + '@7' : p), ...plugins.map(p => p.startsWith('@babel/') ? p + '@7' : p), '@babel/core@7', '@babel/cli@7'],
+      dev: true
+    }
+  }];
   """

--- a/templates/jspm.toml
+++ b/templates/jspm.toml
@@ -1,6 +1,6 @@
 [[template]]
   name = "jspm:generate"
-  definition = """({ generatorEnv = ['browser', 'production', 'module'], ...generateOpts }) => [{
+  definition = """({ autoInstall = false, generatorEnv = ['browser', 'production', 'module'], ...generateOpts }) => [{
     deps: ['node_modules/@jspm/generator', 'node_modules/mkdirp'],
     engine: 'node',
     run: `
@@ -22,9 +22,9 @@
       await writeFile(process.env.TARGET, outHtml);
     `
   }, {
-    template: 'npm:install',
+    template: autoInstall ? 'npm:install' : 'npm:verify',
     args: {
-      packages: ['@jspm/generator@^1.0.0-beta.21', 'mkdirp'],
+      packages: ['@jspm/generator', 'mkdirp'],
       dev: true
     }
   }]

--- a/templates/npm.toml
+++ b/templates/npm.toml
@@ -12,11 +12,28 @@
     }),
     serial: true
   }, ...packages.map(pkg => ({
-    target: `node_modules/${pkg}`,
+    targets: packages.map(pkg => {
+      const versionIndex = pkg.indexOf('@', 1);
+      return `node_modules/${versionIndex === -1 ? pkg : pkg.slice(0, versionIndex)}`;
+    }),
     target_check: 'exists',
     deps: ['npm:init'],
-    run: `npm install ${pkg}${dev ? ' --save-dev' : ''}`
+    run: `npm install ${packages.join(' ')}${dev ? ' -D' : ''}`
   }))];
+  """
+
+# npm verify template
+# instead of installing packages, it just verifies they are present, providing an
+# error and instruction if they are not
+[[template]]
+  name = "npm:verify"
+  definition = """({ packages, dev }) => [{
+    targets: packages.map(pkg => {
+      const versionIndex = pkg.indexOf('@', 1);
+      return `node_modules/${versionIndex === -1 ? pkg : pkg.slice(0, versionIndex)}`;
+    }),
+    run: `echo "\n\\x1b[93mChomp\\x1b[0m: Some packages are missing. Please run \\x1b[1mnpm install ${packages.join(' ')}${dev ? ' -D' : ''}\\x1b[0m\n"`
+  }];
   """
 
 # npm install task

--- a/templates/svelte.toml
+++ b/templates/svelte.toml
@@ -1,6 +1,6 @@
 [[template]]
   name = "svelte"
-  definition = """() => [{
+  definition = """({ autoInstall = false, svelteConfig = null }) => [{
     deps: ['node_modules/svelte', 'node_modules/mkdirp'],
     engine: 'node',
     run: `
@@ -9,13 +9,18 @@
       import mkdirp from 'mkdirp';
       import { dirname } from 'path';
 
+      let config;
+      ${svelteConfig ? `
+        config = await import(${svelteConfig === true ? '"./svelte.config.js"' : svelteConfig});
+      ` : `
+        config = {
+          css: false
+        };
+      `}
+      config.filename = process.env.DEP;
+
       const source = await readFile(process.env.DEP, 'utf-8');
-      const result = compile(source, {
-        // TODO:
-        // - preprocessor support for eg TypeScript
-        filename: process.env.DEP,
-        css: false,
-      });
+      const result = compile(source, config);
 
       mkdirp.sync(dirname(process.env.TARGET));
       const cssFile = process.env.TARGET.replace(/\\.js$/, ".css");
@@ -27,7 +32,7 @@
       ];
     `
   }, {
-    template: 'npm:install',
+    template: autoInstall ? 'npm:install' : 'npm:verify',
     args: {
       packages: ['svelte@3', 'mkdirp'],
       dev: true

--- a/templates/swc.toml
+++ b/templates/swc.toml
@@ -1,10 +1,18 @@
 [[template]]
   name = "swc"
-  definition = """() => [{
+  definition = """({ autoInstall = false, configFile = null, noSwcrc, sourceMaps = true, config = {} }) => [{
     deps: ['node_modules/@swc/core', 'node_modules/@swc/cli'],
-    run: "swc $DEP -o $TARGET"
+    run: `swc $DEP -o $TARGET${
+        noSwcrc ? ' --no-swcrc' : ''
+      }${
+        configFile ? ` --config-file=${configFile}` : ''
+      }${
+        sourceMaps ? ' --source-maps' : ''
+      }${
+        Object.keys(config).length ? ' ' + Object.keys(config).map(key => `-C ${key}=${config[key]}`).join(' ') : ''
+      }`
   }, {
-    template: 'npm:install',
+    template: autoInstall ? 'npm:install' : 'npm:verify',
     args: {
       packages: ['@swc/core@1', '@swc/cli@0.1'],
       dev: true

--- a/test/chompfile.toml
+++ b/test/chompfile.toml
@@ -1,5 +1,4 @@
 version = 0.1
-debug = true
 
 [[task]]
   name = "test"
@@ -32,18 +31,24 @@ debug = true
   template = "jspm:generate"
   target = "app-build.html"
   deps = ["app.html"]
+  [task.args]
+    autoInstall = true
 
 [[task]]
   name = "svelte"
   template = "svelte"
   target = "lib/test.js"
   deps = ["src/test.svelte"]
+  [task.args]
+    autoInstall = true
 
 [[task]]
   name = "swc"
   template = "swc"
   target = "test.js"
   deps = ["test.ts"]
+  [task.args]
+    autoInstall = true
 
 [[task]]
   name = "babel"
@@ -52,3 +57,4 @@ debug = true
   deps = ["test.ts"]
   [task.args]
     presets = ['@babel/preset-typescript']
+    autoInstall = true


### PR DESCRIPTION
This PR updates the templates based on current usability feedback.

It adds an `autoInstall = true` argument to all templates that do npm installs, where when that argument is not explicitly set for the template, there will instead be an error thrown that a package is missing and needs to be installed like:

```
Chomp: Some packages are missing. Please run npm install @babel/core @babel/cli
```

In addition the Babel and SWC templates now use configuration files by default with an argument to disable them.

Template updates:

NPM
* Adds a new `npm:verify` template that is exactly the same as the `npm:install` template but instead of installing, throws and error stopping all subsequent operations with a failure and informs the user with the message `Chomp: Some packages are missing. Please run npm install ...`.

JSPM
* Adds `autoInstall`

Babel
* Adds `autoInstall`, which applies to both Babel itself and any used plugins or presets (passed as plugins and presets array arguments)
* Adds `babelRc` argument that can be true or false. Default is `true`.
* Adds `configFile` argument that can be any string to use. Default is none. We could consider defaulting to `babel.config.js` if it exists, but opting into this while getting the rc automatically is the Babel convention currently.

Swc
* Adds `autoInstall`
* Adds `swcRc` argument that can be true or false, default is `true`.
* Adds `configFile` argument that can be any string. Default is none.
* Adds `sourceMaps` argument that can be true or false. Default is true.
* Adds `config` argument which is a dictionary of dot-separated configuration options to their values, allowing inline configuration.

Svelte
* Adds `autoInstall`
* Adds `svelteConfig` argument that can be any string, default is none. When set, this file will be imported and used as the configuration to drive the Svelte compilation, thus supporting any arbitrary svelte config. The `config.filename` is still set to the dependency being compiled though.
