### PR TITLE
feat: template options refinements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,6 +260,7 @@ dependencies = [
  "async-std",
  "capturing-glob",
  "clap",
+ "convert_case",
  "crossterm",
  "derivative",
  "futures",
@@ -301,6 +302,12 @@ checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
 dependencies = [
  "cache-padded",
 ]
+
+[[package]]
+name = "convert_case"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb4a24b1aaf0fd0ce8b45161144d6f42cd91677fd5940fd431183eb023b3a2b8"
 
 [[package]]
 name = "crossbeam-utils"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ async-recursion = "0.3.2"
 async-std = { version = "1.10.0", features = ["unstable"] }
 capturing-glob = "0.1.1"
 clap = "2.33.3"
+convert_case = "0.5.0"
 crossterm = "0.22.1"
 derivative = "2.2.0"
 futures = "0.3.18"

--- a/README.md
+++ b/README.md
@@ -50,15 +50,16 @@ A number of system templates are provided out of the box in the templates direct
 
 #### npm install
 
-For example, to install an npm library, rather than manually writing an `npm install` call, you can use the `npm:install` template:
+For example, to install an npm library, rather than manually writing an `npm install` call, you can use the `npm` template:
 
 ```chompfile.toml
 version = 0.1
 
 [[task]]
   name = "Install Mocha"
-  template = "npm:install"
-  [task.args]
+  template = "npm"
+  [task.template-opts]
+    auto-install = true
     packages = ['mocha']
     dev = true
 ```
@@ -72,14 +73,15 @@ To compile TypeScript with the SWC template:
 ```toml
 version = 0.1
 
+# Installs SWC automatically if needed
+[default-template-opts.npm]
+  auto-install = true
+
 [[task]]
   name = "typescript"
   template = "swc"
   target = "lib/#.js"
   deps = ["src/#.ts]
-  [task.args]
-    # automatically install swc with npm if not present
-    autoInstall = true
 ```
 
 In the above, all `src/**/*.ts` files will be globbed, have SWC run on them, and output into `lib/[file].js` along with their source maps.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 extern crate clap;
 #[macro_use]
 extern crate lazy_static;
-use crate::chompfile::ServeOptions;
 use crate::chompfile::Chompfile;
 use clap::{App, Arg};
 use std::io::stdout;

--- a/src/templates.toml
+++ b/src/templates.toml
@@ -1,8 +1,11 @@
 ﻿version = 0.1
 [[template]]
 name = "babel"
-definition = """({ autoInstall = false, presets = [], plugins = [], sourceMap = true, babelRc = true, configFile = null }) => [{
-  deps: [...presets.map(p => `node_modules/${p}`), ...plugins.map(p => `node_modules/${p}`), 'node_modules/@babel/core', 'node_modules/@babel/cli'],
+definition = """({ name, targets, deps, env, templateOpts: { presets = [], plugins = [], sourceMap = true, babelRc = true, configFile = null } }) => [{
+  name,
+  targets,
+  deps: [...deps, ...presets.map(p => `node_modules/${p}`), ...plugins.map(p => `node_modules/${p}`), 'node_modules/@babel/core', 'node_modules/@babel/cli'],
+  env,
   run: `babel $DEP -o $TARGET${
       sourceMap ? ' --source-maps' : ''
     }${
@@ -15,28 +18,55 @@ definition = """({ autoInstall = false, presets = [], plugins = [], sourceMap = 
       configFile ? ` --config-file=${configFile.startsWith('./') ? configFile : './' + configFile}` : ''
     }`
 }, {
-  template: autoInstall ? 'npm:install' : 'npm:verify',
-  args: {
+  template: 'npm',
+  templateOpts: {
     packages: [...presets.map(p => p.startsWith('@babel/') ? p + '@7' : p), ...plugins.map(p => p.startsWith('@babel/') ? p + '@7' : p), '@babel/core@7', '@babel/cli@7'],
     dev: true
   }
 }];
 """
 [[template]]
-name = "jspm:generate"
-definition = """({ autoInstall = false, generatorEnv = ['browser', 'production', 'module'], ...generateOpts }) => [{
-  deps: ['node_modules/@jspm/generator', 'node_modules/mkdirp'],
+name = "jspm"
+definition = """({ name, targets, deps, env, templateOpts: {
+  env: generatorEnv = ['browser', 'production', 'module'],
+  preload,
+  integrity,
+  whitespace,
+  esModuleShims,
+  ...generateOpts
+} }) => [{
+  name,
+  targets,
+  deps: [...deps, 'node_modules/@jspm/generator', 'node_modules/mkdirp'],
+  env,
   engine: 'node',
   run: `
     import { Generator } from '@jspm/generator';
     import { readFile, writeFile } from 'fs/promises';
     import { pathToFileURL } from 'url';
     import mkdirp from 'mkdirp';
-    import { dirname } from 'path';
+    import { dirname, relative, resolve } from 'path';
 
     const opts = ${JSON.stringify(generateOpts)};
-
     const htmlUrl = pathToFileURL(process.env.TARGET);
+
+    if (opts.resolutions) {
+      const newResolutions = {};
+      // renormalize relative resolutions relative to cwd
+      const cwd = process.cwd();
+      for (const key of Object.keys(opts.resolutions)) {
+        const target = opts.resolutions[key];
+        if (!target.startsWith('./') && !target.startsWith('../')) {
+          newResolutions[key] = target;
+          continue;
+        }
+        const normalizedTarget = relative(dirname(resolve(cwd, process.env.TARGET)), resolve(cwd, target)).replace(/\\\\\\\\/g, '/');
+        newResolutions[key] = normalizedTarget;
+      }
+      console.log(newResolutions);
+      opts.resolutions = newResolutions;
+    }
+
     const generator = new Generator({
       mapUrl: htmlUrl,
       env: ${JSON.stringify(generatorEnv)},
@@ -44,50 +74,47 @@ definition = """({ autoInstall = false, generatorEnv = ['browser', 'production',
     });
 
     const htmlSource = await readFile(process.env.DEP, 'utf-8');
-    opts.htmlUrl = htmlUrl;
-    const outHtml = await generator.htmlGenerate(htmlSource, opts);
+    const htmlOpts = ${JSON.stringify({ preload, integrity, whitespace, esModuleShims })};
+    htmlOpts.htmlUrl = htmlUrl;
+    const outHtml = await generator.htmlGenerate(htmlSource, htmlOpts);
 
     mkdirp.sync(dirname(process.env.TARGET));
     await writeFile(process.env.TARGET, outHtml);
   `
 }, {
-  template: autoInstall ? 'npm:install' : 'npm:verify',
-  args: {
+  template: 'npm',
+  templateOpts: {
     packages: ['@jspm/generator', 'mkdirp'],
     dev: true
   }
 }]
 """
-# npm packages template
-# - takes an array of packages, and ensures they are installed in node_modules
-# - depends on the npm install task, which ensures package.json + lock
-# - only if the initial install doesn't locate the packages do we add new installs
-# - installs packages one by one to not reinstall any specific existing package
 [[template]]
-name = "npm:install"
-definition = """({ packages, dev }, { PKG_MANAGER = 'npm' }) => [{
-  deps: packages.map(pkg => {
+name = "npm"
+definition = """({ name, deps, env, templateOpts: { packages, dev, pkgManager = 'npm', autoInstall } }) => autoInstall ? [{
+  name,
+  deps: [...deps, ...packages.map(pkg => {
     const versionIndex = pkg.indexOf('@', 1);
     return `node_modules/${versionIndex === -1 ? pkg : pkg.slice(0, versionIndex)}`;
-  }),
+  })],
   serial: true
-}, ...packages.map(pkg => ({
-  targets: packages.map(pkg => {
-    const versionIndex = pkg.indexOf('@', 1);
-    return `node_modules/${versionIndex === -1 ? pkg : pkg.slice(0, versionIndex)}`;
-  }),
-  target_check: 'exists',
-  deps: ['npm:init'],
-  run: `${PKG_MANAGER} install ${packages.join(' ')}${dev ? ' -D' : ''}`
-}))];
-"""
-
-# npm verify template
-# instead of installing packages, it just verifies they are present, providing an
-# error and instruction if they are not
-[[template]]
-name = "npm:verify"
-definition = """({ packages, dev }) => [{
+}, ...packages.map(pkg => {
+  const versionIndex = pkg.indexOf('@', 1);
+  return {
+    target: `node_modules/${versionIndex === -1 ? pkg : pkg.slice(0, versionIndex)}`,
+    targetCheck: 'exists',
+    deps: ['npm:init'],
+    env,
+    run: `${pkgManager} install ${packages.join(' ')}${dev ? ' -D' : ''}`
+  };
+}), {
+  name: 'npm:init',
+  target: 'package.json',
+  env,
+  run: `${pkgManager} init -y`
+}] : [{
+  name,
+  env,
   targets: packages.map(pkg => {
     const versionIndex = pkg.indexOf('@', 1);
     return `node_modules/${versionIndex === -1 ? pkg : pkg.slice(0, versionIndex)}`;
@@ -95,44 +122,13 @@ definition = """({ packages, dev }) => [{
   run: `echo "\n\\x1b[93mChomp\\x1b[0m: Some packages are missing. Please run \\x1b[1mnpm install ${packages.join(' ')}${dev ? ' -D' : ''}\\x1b[0m\n"`
 }];
 """
-
-# npm install task
-# - depends on npm init (package.json existing)
-# - checks if package-lock.json exists
-# - if not, runs npm install
-[[task]]
-name = "npm:install-all"
-template = "npm:_install-all"
-
-[[template]]
-name = "npm:_install-all"
-definition = """({}, { PKG_MANAGER = 'npm' }) => [{
-  target: PKG_MANAGER === 'pnpm' ? 'pnpm-lock.yaml' : PKG_MANAGER === 'yarn' ? 'yarn.lock' : 'package-lock.json',
-  // opts-out of mtime invalidation (package.json mtime > package-lock.json mtime)
-  target_check: 'exists',
-  deps: ['npm:init'],
-  run: `${PKG_MANAGER} install`
-}];
-"""
-
-# npm init task
-# - checks if the package.json exists, if it does its done
-# - if the package.json does not exist, runs npm init with default prompts
-[[task]]
-name = "npm:init"
-template = "npm:_init"
-
-[[template]]
-name = "npm:_init"
-definition = """({}, { PKG_MANAGER = 'npm' }) => [{
-  target: 'package.json',
-  run: `${PKG_MANAGER} init -y`
-}];
-"""
 [[template]]
 name = "prettier"
-definition = """({ autoInstall = false, files = '.', check = false, write = true, config = null, noErrorOnUnmatchedPattern = false }) => [{
-  deps: ['node_modules/prettier'],
+definition = """({ name, targets, deps, env, templateOpts: { files = '.', check = false, write = true, config = null, noErrorOnUnmatchedPattern = false } }) => [{
+  name,
+  targets,
+  deps: [...deps, 'node_modules/prettier'],
+  env,
   run: `prettier ${files} ${
       check ? ' --check' : ''
     }${
@@ -143,8 +139,8 @@ definition = """({ autoInstall = false, files = '.', check = false, write = true
       noErrorOnUnmatchedPattern ? ' --no-error-on-unmatched-pattern' : ''
     }`
 }, {
-  template: autoInstall ? 'npm:install' : 'npm:verify',
-  args: {
+  template: 'npm',
+  templateOpts: {
     packages: ['prettier'],
     dev: true
   }
@@ -152,8 +148,11 @@ definition = """({ autoInstall = false, files = '.', check = false, write = true
 """
 [[template]]
 name = "svelte"
-definition = """({ autoInstall = false, svelteConfig = null }) => [{
-  deps: ['node_modules/svelte', 'node_modules/mkdirp'],
+definition = """({ name, targets, deps, env, templateOpts: { svelteConfig = null } }) => [{
+  name,
+  targets,
+  deps: [...deps, 'node_modules/svelte', 'node_modules/mkdirp'],
+  env,
   engine: 'node',
   run: `
     import { readFile, writeFile } from 'fs/promises';
@@ -184,8 +183,8 @@ definition = """({ autoInstall = false, svelteConfig = null }) => [{
     ];
   `
 }, {
-  template: autoInstall ? 'npm:install' : 'npm:verify',
-  args: {
+  template: 'npm',
+  templateOpts: {
     packages: ['svelte@3', 'mkdirp'],
     dev: true
   }
@@ -193,8 +192,11 @@ definition = """({ autoInstall = false, svelteConfig = null }) => [{
 """
 [[template]]
 name = "swc"
-definition = """({ autoInstall = false, configFile = null, swcRc, sourceMaps = true, config = {} }) => [{
-  deps: ['node_modules/@swc/core', 'node_modules/@swc/cli'],
+definition = """({ name, targets, deps, env, templateOpts: { configFile = null, swcRc, sourceMaps = true, config = {} } }) => [{
+  name,
+  targets,
+  deps: [...deps, 'node_modules/@swc/core', 'node_modules/@swc/cli'],
+  env,
   run: `swc $DEP -o $TARGET${
       !swcRc ? ' --no-swcrc' : ''
     }${
@@ -205,8 +207,8 @@ definition = """({ autoInstall = false, configFile = null, swcRc, sourceMaps = t
       Object.keys(config).length ? ' ' + Object.keys(config).map(key => `-C ${key}=${config[key]}`).join(' ') : ''
     }`
 }, {
-  template: autoInstall ? 'npm:install' : 'npm:verify',
-  args: {
+  template: 'npm',
+  templateOpts: {
     packages: ['@swc/core@1', '@swc/cli@0.1'],
     dev: true
   }

--- a/templates/babel.toml
+++ b/templates/babel.toml
@@ -1,7 +1,10 @@
 [[template]]
 name = "babel"
-definition = """({ autoInstall = false, presets = [], plugins = [], sourceMap = true, babelRc = true, configFile = null }) => [{
-  deps: [...presets.map(p => `node_modules/${p}`), ...plugins.map(p => `node_modules/${p}`), 'node_modules/@babel/core', 'node_modules/@babel/cli'],
+definition = """({ name, targets, deps, env, templateOpts: { presets = [], plugins = [], sourceMap = true, babelRc = true, configFile = null } }) => [{
+  name,
+  targets,
+  deps: [...deps, ...presets.map(p => `node_modules/${p}`), ...plugins.map(p => `node_modules/${p}`), 'node_modules/@babel/core', 'node_modules/@babel/cli'],
+  env,
   run: `babel $DEP -o $TARGET${
       sourceMap ? ' --source-maps' : ''
     }${
@@ -14,8 +17,8 @@ definition = """({ autoInstall = false, presets = [], plugins = [], sourceMap = 
       configFile ? ` --config-file=${configFile.startsWith('./') ? configFile : './' + configFile}` : ''
     }`
 }, {
-  template: autoInstall ? 'npm:install' : 'npm:verify',
-  args: {
+  template: 'npm',
+  templateOpts: {
     packages: [...presets.map(p => p.startsWith('@babel/') ? p + '@7' : p), ...plugins.map(p => p.startsWith('@babel/') ? p + '@7' : p), '@babel/core@7', '@babel/cli@7'],
     dev: true
   }

--- a/templates/jspm.toml
+++ b/templates/jspm.toml
@@ -1,18 +1,44 @@
 [[template]]
-name = "jspm:generate"
-definition = """({ autoInstall = false, generatorEnv = ['browser', 'production', 'module'], ...generateOpts }) => [{
-  deps: ['node_modules/@jspm/generator', 'node_modules/mkdirp'],
+name = "jspm"
+definition = """({ name, targets, deps, env, templateOpts: {
+  env: generatorEnv = ['browser', 'production', 'module'],
+  preload,
+  integrity,
+  whitespace,
+  esModuleShims,
+  ...generateOpts
+} }) => [{
+  name,
+  targets,
+  deps: [...deps, 'node_modules/@jspm/generator', 'node_modules/mkdirp'],
+  env,
   engine: 'node',
   run: `
     import { Generator } from '@jspm/generator';
     import { readFile, writeFile } from 'fs/promises';
     import { pathToFileURL } from 'url';
     import mkdirp from 'mkdirp';
-    import { dirname } from 'path';
+    import { dirname, relative, resolve } from 'path';
 
     const opts = ${JSON.stringify(generateOpts)};
-
     const htmlUrl = pathToFileURL(process.env.TARGET);
+
+    if (opts.resolutions) {
+      const newResolutions = {};
+      // renormalize relative resolutions relative to cwd
+      const cwd = process.cwd();
+      for (const key of Object.keys(opts.resolutions)) {
+        const target = opts.resolutions[key];
+        if (!target.startsWith('./') && !target.startsWith('../')) {
+          newResolutions[key] = target;
+          continue;
+        }
+        const normalizedTarget = relative(dirname(resolve(cwd, process.env.TARGET)), resolve(cwd, target)).replace(/\\\\\\\\/g, '/');
+        newResolutions[key] = normalizedTarget;
+      }
+      opts.resolutions = newResolutions;
+    }
+
     const generator = new Generator({
       mapUrl: htmlUrl,
       env: ${JSON.stringify(generatorEnv)},
@@ -20,15 +46,16 @@ definition = """({ autoInstall = false, generatorEnv = ['browser', 'production',
     });
 
     const htmlSource = await readFile(process.env.DEP, 'utf-8');
-    opts.htmlUrl = htmlUrl;
-    const outHtml = await generator.htmlGenerate(htmlSource, opts);
+    const htmlOpts = ${JSON.stringify({ preload, integrity, whitespace, esModuleShims })};
+    htmlOpts.htmlUrl = htmlUrl;
+    const outHtml = await generator.htmlGenerate(htmlSource, htmlOpts);
 
     mkdirp.sync(dirname(process.env.TARGET));
     await writeFile(process.env.TARGET, outHtml);
   `
 }, {
-  template: autoInstall ? 'npm:install' : 'npm:verify',
-  args: {
+  template: 'npm',
+  templateOpts: {
     packages: ['@jspm/generator', 'mkdirp'],
     dev: true
   }

--- a/templates/npm.toml
+++ b/templates/npm.toml
@@ -1,71 +1,33 @@
-# npm packages template
-# - takes an array of packages, and ensures they are installed in node_modules
-# - depends on the npm install task, which ensures package.json + lock
-# - only if the initial install doesn't locate the packages do we add new installs
-# - installs packages one by one to not reinstall any specific existing package
 [[template]]
-name = "npm:install"
-definition = """({ packages, dev }, { PKG_MANAGER = 'npm' }) => [{
-  deps: packages.map(pkg => {
+name = "npm"
+definition = """({ name, deps, env, templateOpts: { packages, dev, pkgManager = 'npm', autoInstall } }) => autoInstall ? [{
+  name,
+  deps: [...deps, ...packages.map(pkg => {
     const versionIndex = pkg.indexOf('@', 1);
     return `node_modules/${versionIndex === -1 ? pkg : pkg.slice(0, versionIndex)}`;
-  }),
+  })],
   serial: true
-}, ...packages.map(pkg => ({
-  targets: packages.map(pkg => {
-    const versionIndex = pkg.indexOf('@', 1);
-    return `node_modules/${versionIndex === -1 ? pkg : pkg.slice(0, versionIndex)}`;
-  }),
-  target_check: 'exists',
-  deps: ['npm:init'],
-  run: `${PKG_MANAGER} install ${packages.join(' ')}${dev ? ' -D' : ''}`
-}))];
-"""
-
-# npm verify template
-# instead of installing packages, it just verifies they are present, providing an
-# error and instruction if they are not
-[[template]]
-name = "npm:verify"
-definition = """({ packages, dev }) => [{
+}, ...packages.map(pkg => {
+  const versionIndex = pkg.indexOf('@', 1);
+  return {
+    target: `node_modules/${versionIndex === -1 ? pkg : pkg.slice(0, versionIndex)}`,
+    targetCheck: 'exists',
+    deps: ['npm:init'],
+    env,
+    run: `${pkgManager} install ${packages.join(' ')}${dev ? ' -D' : ''}`
+  };
+}), {
+  name: 'npm:init',
+  target: 'package.json',
+  env,
+  run: `${pkgManager} init -y`
+}] : [{
+  name,
+  env,
   targets: packages.map(pkg => {
     const versionIndex = pkg.indexOf('@', 1);
     return `node_modules/${versionIndex === -1 ? pkg : pkg.slice(0, versionIndex)}`;
   }),
   run: `echo "\n\\x1b[93mChomp\\x1b[0m: Some packages are missing. Please run \\x1b[1mnpm install ${packages.join(' ')}${dev ? ' -D' : ''}\\x1b[0m\n"`
-}];
-"""
-
-# npm install task
-# - depends on npm init (package.json existing)
-# - checks if package-lock.json exists
-# - if not, runs npm install
-[[task]]
-name = "npm:install-all"
-template = "npm:_install-all"
-
-[[template]]
-name = "npm:_install-all"
-definition = """({}, { PKG_MANAGER = 'npm' }) => [{
-  target: PKG_MANAGER === 'pnpm' ? 'pnpm-lock.yaml' : PKG_MANAGER === 'yarn' ? 'yarn.lock' : 'package-lock.json',
-  // opts-out of mtime invalidation (package.json mtime > package-lock.json mtime)
-  target_check: 'exists',
-  deps: ['npm:init'],
-  run: `${PKG_MANAGER} install`
-}];
-"""
-
-# npm init task
-# - checks if the package.json exists, if it does its done
-# - if the package.json does not exist, runs npm init with default prompts
-[[task]]
-name = "npm:init"
-template = "npm:_init"
-
-[[template]]
-name = "npm:_init"
-definition = """({}, { PKG_MANAGER = 'npm' }) => [{
-  target: 'package.json',
-  run: `${PKG_MANAGER} init -y`
 }];
 """

--- a/templates/prettier.toml
+++ b/templates/prettier.toml
@@ -1,7 +1,10 @@
 [[template]]
 name = "prettier"
-definition = """({ autoInstall = false, files = '.', check = false, write = true, config = null, noErrorOnUnmatchedPattern = false }) => [{
-  deps: ['node_modules/prettier'],
+definition = """({ name, targets, deps, env, templateOpts: { files = '.', check = false, write = true, config = null, noErrorOnUnmatchedPattern = false } }) => [{
+  name,
+  targets,
+  deps: [...deps, 'node_modules/prettier'],
+  env,
   run: `prettier ${files} ${
       check ? ' --check' : ''
     }${
@@ -12,8 +15,8 @@ definition = """({ autoInstall = false, files = '.', check = false, write = true
       noErrorOnUnmatchedPattern ? ' --no-error-on-unmatched-pattern' : ''
     }`
 }, {
-  template: autoInstall ? 'npm:install' : 'npm:verify',
-  args: {
+  template: 'npm',
+  templateOpts: {
     packages: ['prettier'],
     dev: true
   }

--- a/templates/svelte.toml
+++ b/templates/svelte.toml
@@ -1,7 +1,10 @@
 [[template]]
 name = "svelte"
-definition = """({ autoInstall = false, svelteConfig = null }) => [{
-  deps: ['node_modules/svelte', 'node_modules/mkdirp'],
+definition = """({ name, targets, deps, env, templateOpts: { svelteConfig = null } }) => [{
+  name,
+  targets,
+  deps: [...deps, 'node_modules/svelte', 'node_modules/mkdirp'],
+  env,
   engine: 'node',
   run: `
     import { readFile, writeFile } from 'fs/promises';
@@ -32,8 +35,8 @@ definition = """({ autoInstall = false, svelteConfig = null }) => [{
     ];
   `
 }, {
-  template: autoInstall ? 'npm:install' : 'npm:verify',
-  args: {
+  template: 'npm',
+  templateOpts: {
     packages: ['svelte@3', 'mkdirp'],
     dev: true
   }

--- a/templates/swc.toml
+++ b/templates/swc.toml
@@ -1,7 +1,10 @@
 [[template]]
 name = "swc"
-definition = """({ autoInstall = false, configFile = null, swcRc, sourceMaps = true, config = {} }) => [{
-  deps: ['node_modules/@swc/core', 'node_modules/@swc/cli'],
+definition = """({ name, targets, deps, env, templateOpts: { configFile = null, swcRc, sourceMaps = true, config = {} } }) => [{
+  name,
+  targets,
+  deps: [...deps, 'node_modules/@swc/core', 'node_modules/@swc/cli'],
+  env,
   run: `swc $DEP -o $TARGET${
       !swcRc ? ' --no-swcrc' : ''
     }${
@@ -12,8 +15,8 @@ definition = """({ autoInstall = false, configFile = null, swcRc, sourceMaps = t
       Object.keys(config).length ? ' ' + Object.keys(config).map(key => `-C ${key}=${config[key]}`).join(' ') : ''
     }`
 }, {
-  template: autoInstall ? 'npm:install' : 'npm:verify',
-  args: {
+  template: 'npm',
+  templateOpts: {
     packages: ['@swc/core@1', '@swc/cli@0.1'],
     dev: true
   }

--- a/test/chompfile.toml
+++ b/test/chompfile.toml
@@ -1,5 +1,8 @@
 version = 0.1
 
+[default-template-opts.npm]
+  auto-install = true
+
 [[task]]
   name = "test"
   serial = true
@@ -54,38 +57,29 @@ version = 0.1
 [[task]]
   name = "prettier"
   template = "prettier"
-  [task.args]
-    autoInstall = true
 
 [[task]]
   name = "jspm"
-  template = "jspm:generate"
+  template = "jspm"
   target = "app-build.html"
   deps = ["app.html"]
-  [task.args]
-    autoInstall = true
 
 [[task]]
   name = "svelte"
   template = "svelte"
   target = "lib/test.js"
   deps = ["src/test.svelte"]
-  [task.args]
-    autoInstall = true
 
 [[task]]
   name = "swc"
   template = "swc"
   target = "test.js"
   deps = ["test.ts"]
-  [task.args]
-    autoInstall = true
 
 [[task]]
   name = "babel"
   template = "babel"
   target = "test-babel.js"
   deps = ["test.ts"]
-  [task.args]
+  [task.template-opts]
     presets = ['@babel/preset-typescript']
-    autoInstall = true


### PR DESCRIPTION
This PR implements a number of renamings and adjustments to the template system, fixing a number of issues in the process.

* As a rule, all properties in the `chompfile.toml` are now `kebab-case` per convention.
* `[task.args]` for setting template options has been renamed to `[task.template-opts]` to make it clearer what this is doing.
* A new `[default-template-opts.template-name]` top-level setting is now provided for setting default options by template. Resolves https://github.com/guybedford/chomp/issues/27.
* `autoInstall` is now `auto-install`, and `PKG_MANAGER` is no longer an environment variable but rather a template option `pkg-manager`
* The `jspm:generate` template is renamed to just `jspm`.

This PR also adopts a manual chaining of template options within the template definitions themselves, although that is mostly an implementation detail.

This PR also includes various template fixes including fixing https://github.com/guybedford/chomp/issues/29 and some normalization in the JSPM generator and Babel plugins.

TLDR; here's a before after configuration example:

BEFORE:

```toml
version = 0.1

[env]
  PKG_MANAGER = "pnpm"

[[task]]
  template = "jspm"
  [task.args]
    autoInstall = true
    env = ["browser", "production"]
```

AFTER:

```toml
version = 0.1

[default-template-opts.npm]
  auto-install = true
  pkg-manager = 'pnpm'

[[task]]
  template = "jspm"
  [task.template-opts]
    env = ["browser", "production"]
```

While this is strictly a breaking change, since no release has yet been made there is no version bump.