### PR TITLE
Rename template-opts -> options

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ version = 0.1
 [[task]]
   name = "Install Mocha"
   template = "npm"
-  [task.template-opts]
+  [task.options]
     auto-install = true
     packages = ['mocha']
     dev = true
@@ -74,7 +74,7 @@ To compile TypeScript with the SWC template:
 version = 0.1
 
 # Installs SWC automatically if needed
-[default-template-opts.npm]
+[default-options.npm]
   auto-install = true
 
 [[task]]

--- a/README.md
+++ b/README.md
@@ -73,15 +73,14 @@ To compile TypeScript with the SWC template:
 ```toml
 version = 0.1
 
-# Installs SWC automatically if needed
-[default-options.npm]
-  auto-install = true
-
 [[task]]
   name = "typescript"
   template = "swc"
   target = "lib/#.js"
   deps = ["src/#.ts]
+  # Installs SWC automatically if needed
+  [task.options]
+    auto-install = true
 ```
 
 In the above, all `src/**/*.ts` files will be globbed, have SWC run on them, and output into `lib/[file].js` along with their source maps.

--- a/src/chompfile.rs
+++ b/src/chompfile.rs
@@ -29,7 +29,7 @@ pub struct Chompfile {
     #[serde(default, skip_serializing_if = "is_default")]
     pub template: Vec<ChompTemplate>,
     #[serde(default, skip_serializing_if = "is_default")]
-    pub default_template_opts: BTreeMap<String, BTreeMap<String, toml::value::Value>>,
+    pub default_options: BTreeMap<String, BTreeMap<String, toml::value::Value>>,
 }
 
 #[derive(Debug, Serialize, PartialEq, Deserialize, Clone)]
@@ -77,7 +77,7 @@ pub struct ChompTaskMaybeTemplated {
     pub run: Option<String>,
     pub engine: Option<ChompEngine>,
     pub template: Option<String>,
-    pub template_opts: Option<BTreeMap<String, toml::value::Value>>,
+    pub options: Option<BTreeMap<String, toml::value::Value>>,
 }
 
 impl ChompTaskMaybeTemplated {
@@ -112,7 +112,7 @@ pub struct ChompTaskMaybeTemplatedNoDefault {
     pub run: Option<String>,
     pub engine: Option<ChompEngine>,
     pub template: Option<String>,
-    pub template_opts: Option<BTreeMap<String, toml::value::Value>>,
+    pub options: Option<BTreeMap<String, toml::value::Value>>,
 }
 
 #[derive(Debug, Serialize, PartialEq, Deserialize)]

--- a/src/task.rs
+++ b/src/task.rs
@@ -298,26 +298,26 @@ pub async fn check_target_mtimes(targets: Vec<String>) -> Option<Duration> {
     last_mtime
 }
 
-fn create_template_opts(
+fn create_options(
     template: &str,
-    task_template_opts: &Option<BTreeMap<String, toml::value::Value>>,
+    task_options: &Option<BTreeMap<String, toml::value::Value>>,
     default_opts: &BTreeMap<String, BTreeMap<String, toml::value::Value>>,
 ) -> BTreeMap<String, toml::value::Value> {
-    let mut template_opts = BTreeMap::new();
-    if let Some(task_template_opts) = task_template_opts {
-        for (key, value) in task_template_opts {
-            template_opts.insert(key.from_case(Case::Kebab).to_case(Case::Camel), value.clone());
+    let mut options = BTreeMap::new();
+    if let Some(task_options) = task_options {
+        for (key, value) in task_options {
+            options.insert(key.from_case(Case::Kebab).to_case(Case::Camel), value.clone());
         }
     };
-    if let Some(default_template_opts) = default_opts.get(template) {
-        for (key, value) in default_template_opts {
-            if template_opts.get(key).is_some() {
+    if let Some(default_options) = default_opts.get(template) {
+        for (key, value) in default_options {
+            if options.get(key).is_some() {
                 continue;
             }
-            template_opts.insert(key.from_case(Case::Kebab).to_case(Case::Camel), value.clone());
+            options.insert(key.from_case(Case::Kebab).to_case(Case::Camel), value.clone());
         }
     }
-    template_opts
+    options
 }
 
 impl<'a> Runner<'a> {
@@ -353,11 +353,11 @@ impl<'a> Runner<'a> {
         let mut task_queue: VecDeque<ChompTaskMaybeTemplatedNoDefault> = VecDeque::new();
         for task in runner.chompfile.task.iter() {
             let template = task.template.clone();
-            let template_opts = if let Some(ref template) = template {
-                Some(create_template_opts(
+            let options = if let Some(ref template) = template {
+                Some(create_options(
                     &template,
-                    &task.template_opts,
-                    &chompfile.default_template_opts,
+                    &task.options,
+                    &chompfile.default_options,
                 ))
             } else {
                 None
@@ -374,7 +374,7 @@ impl<'a> Runner<'a> {
                 run: task.run.clone(),
                 engine: task.engine,
                 template,
-                template_opts,
+                options,
             });
         }
         while task_queue.len() > 0 {
@@ -434,10 +434,10 @@ impl<'a> Runner<'a> {
                     template_task.targets = Some(vec![]);
                 }
                 if let Some(ref template) = template_task.template {
-                    template_task.template_opts = Some(create_template_opts(
+                    template_task.options = Some(create_options(
                         &template,
-                        &template_task.template_opts,
-                        &chompfile.default_template_opts,
+                        &template_task.options,
+                        &chompfile.default_options,
                     ));
                 }
                 task_queue.push_front(template_task);

--- a/src/templates.toml
+++ b/src/templates.toml
@@ -1,7 +1,7 @@
 ﻿version = 0.1
 [[template]]
 name = "babel"
-definition = """({ name, targets, deps, env, templateOpts: { presets = [], plugins = [], sourceMap = true, babelRc = true, configFile = null } }) => [{
+definition = """({ name, targets, deps, env, options: { presets = [], plugins = [], sourceMap = true, babelRc = true, configFile = null } }) => [{
   name,
   targets,
   deps: [...deps, ...presets.map(p => `node_modules/${p}`), ...plugins.map(p => `node_modules/${p}`), 'node_modules/@babel/core', 'node_modules/@babel/cli'],
@@ -19,7 +19,7 @@ definition = """({ name, targets, deps, env, templateOpts: { presets = [], plugi
     }`
 }, {
   template: 'npm',
-  templateOpts: {
+  options: {
     packages: [...presets.map(p => p.startsWith('@babel/') ? p + '@7' : p), ...plugins.map(p => p.startsWith('@babel/') ? p + '@7' : p), '@babel/core@7', '@babel/cli@7'],
     dev: true
   }
@@ -27,7 +27,7 @@ definition = """({ name, targets, deps, env, templateOpts: { presets = [], plugi
 """
 [[template]]
 name = "jspm"
-definition = """({ name, targets, deps, env, templateOpts: {
+definition = """({ name, targets, deps, env, options: {
   env: generatorEnv = ['browser', 'production', 'module'],
   preload,
   integrity,
@@ -63,7 +63,6 @@ definition = """({ name, targets, deps, env, templateOpts: {
         const normalizedTarget = relative(dirname(resolve(cwd, process.env.TARGET)), resolve(cwd, target)).replace(/\\\\\\\\/g, '/');
         newResolutions[key] = normalizedTarget;
       }
-      console.log(newResolutions);
       opts.resolutions = newResolutions;
     }
 
@@ -83,7 +82,7 @@ definition = """({ name, targets, deps, env, templateOpts: {
   `
 }, {
   template: 'npm',
-  templateOpts: {
+  options: {
     packages: ['@jspm/generator', 'mkdirp'],
     dev: true
   }
@@ -91,7 +90,7 @@ definition = """({ name, targets, deps, env, templateOpts: {
 """
 [[template]]
 name = "npm"
-definition = """({ name, deps, env, templateOpts: { packages, dev, pkgManager = 'npm', autoInstall } }) => autoInstall ? [{
+definition = """({ name, deps, env, options: { packages, dev, pkgManager = 'npm', autoInstall } }) => autoInstall ? [{
   name,
   deps: [...deps, ...packages.map(pkg => {
     const versionIndex = pkg.indexOf('@', 1);
@@ -124,7 +123,7 @@ definition = """({ name, deps, env, templateOpts: { packages, dev, pkgManager = 
 """
 [[template]]
 name = "prettier"
-definition = """({ name, targets, deps, env, templateOpts: { files = '.', check = false, write = true, config = null, noErrorOnUnmatchedPattern = false } }) => [{
+definition = """({ name, targets, deps, env, options: { files = '.', check = false, write = true, config = null, noErrorOnUnmatchedPattern = false } }) => [{
   name,
   targets,
   deps: [...deps, 'node_modules/prettier'],
@@ -140,7 +139,7 @@ definition = """({ name, targets, deps, env, templateOpts: { files = '.', check 
     }`
 }, {
   template: 'npm',
-  templateOpts: {
+  options: {
     packages: ['prettier'],
     dev: true
   }
@@ -148,7 +147,7 @@ definition = """({ name, targets, deps, env, templateOpts: { files = '.', check 
 """
 [[template]]
 name = "svelte"
-definition = """({ name, targets, deps, env, templateOpts: { svelteConfig = null } }) => [{
+definition = """({ name, targets, deps, env, options: { svelteConfig = null } }) => [{
   name,
   targets,
   deps: [...deps, 'node_modules/svelte', 'node_modules/mkdirp'],
@@ -184,7 +183,7 @@ definition = """({ name, targets, deps, env, templateOpts: { svelteConfig = null
   `
 }, {
   template: 'npm',
-  templateOpts: {
+  options: {
     packages: ['svelte@3', 'mkdirp'],
     dev: true
   }
@@ -192,7 +191,7 @@ definition = """({ name, targets, deps, env, templateOpts: { svelteConfig = null
 """
 [[template]]
 name = "swc"
-definition = """({ name, targets, deps, env, templateOpts: { configFile = null, swcRc, sourceMaps = true, config = {} } }) => [{
+definition = """({ name, targets, deps, env, options: { configFile = null, swcRc, sourceMaps = true, config = {} } }) => [{
   name,
   targets,
   deps: [...deps, 'node_modules/@swc/core', 'node_modules/@swc/cli'],
@@ -208,7 +207,7 @@ definition = """({ name, targets, deps, env, templateOpts: { configFile = null, 
     }`
 }, {
   template: 'npm',
-  templateOpts: {
+  options: {
     packages: ['@swc/core@1', '@swc/cli@0.1'],
     dev: true
   }

--- a/src/templates.toml
+++ b/src/templates.toml
@@ -1,7 +1,7 @@
 ﻿version = 0.1
 [[template]]
 name = "babel"
-definition = """({ name, targets, deps, env, options: { presets = [], plugins = [], sourceMap = true, babelRc = true, configFile = null } }) => [{
+definition = """({ name, targets, deps, env, options: { presets = [], plugins = [], sourceMap = true, babelRc = true, configFile = null, autoInstall } }) => [{
   name,
   targets,
   deps: [...deps, ...presets.map(p => `node_modules/${p}`), ...plugins.map(p => `node_modules/${p}`), 'node_modules/@babel/core', 'node_modules/@babel/cli'],
@@ -21,7 +21,8 @@ definition = """({ name, targets, deps, env, options: { presets = [], plugins = 
   template: 'npm',
   options: {
     packages: [...presets.map(p => p.startsWith('@babel/') ? p + '@7' : p), ...plugins.map(p => p.startsWith('@babel/') ? p + '@7' : p), '@babel/core@7', '@babel/cli@7'],
-    dev: true
+    dev: true,
+    autoInstall: autoInstall
   }
 }];
 """
@@ -90,7 +91,7 @@ definition = """({ name, targets, deps, env, options: {
 """
 [[template]]
 name = "npm"
-definition = """({ name, deps, env, options: { packages, dev, pkgManager = 'npm', autoInstall } }) => autoInstall ? [{
+definition = """({ name, deps, env, options: { packages, dev, packageManager = 'npm', autoInstall } }) => autoInstall ? [{
   name,
   deps: [...deps, ...packages.map(pkg => {
     const versionIndex = pkg.indexOf('@', 1);
@@ -104,13 +105,13 @@ definition = """({ name, deps, env, options: { packages, dev, pkgManager = 'npm'
     targetCheck: 'exists',
     deps: ['npm:init'],
     env,
-    run: `${pkgManager} install ${packages.join(' ')}${dev ? ' -D' : ''}`
+    run: `${packageManager} install ${packages.join(' ')}${dev ? ' -D' : ''}`
   };
 }), {
   name: 'npm:init',
   target: 'package.json',
   env,
-  run: `${pkgManager} init -y`
+  run: `${packageManager} init -y`
 }] : [{
   name,
   env,

--- a/templates/babel.toml
+++ b/templates/babel.toml
@@ -1,6 +1,6 @@
 [[template]]
 name = "babel"
-definition = """({ name, targets, deps, env, options: { presets = [], plugins = [], sourceMap = true, babelRc = true, configFile = null } }) => [{
+definition = """({ name, targets, deps, env, options: { presets = [], plugins = [], sourceMap = true, babelRc = true, configFile = null, autoInstall } }) => [{
   name,
   targets,
   deps: [...deps, ...presets.map(p => `node_modules/${p}`), ...plugins.map(p => `node_modules/${p}`), 'node_modules/@babel/core', 'node_modules/@babel/cli'],
@@ -20,7 +20,8 @@ definition = """({ name, targets, deps, env, options: { presets = [], plugins = 
   template: 'npm',
   options: {
     packages: [...presets.map(p => p.startsWith('@babel/') ? p + '@7' : p), ...plugins.map(p => p.startsWith('@babel/') ? p + '@7' : p), '@babel/core@7', '@babel/cli@7'],
-    dev: true
+    dev: true,
+    autoInstall
   }
 }];
 """

--- a/templates/babel.toml
+++ b/templates/babel.toml
@@ -1,6 +1,6 @@
 [[template]]
 name = "babel"
-definition = """({ name, targets, deps, env, templateOpts: { presets = [], plugins = [], sourceMap = true, babelRc = true, configFile = null } }) => [{
+definition = """({ name, targets, deps, env, options: { presets = [], plugins = [], sourceMap = true, babelRc = true, configFile = null } }) => [{
   name,
   targets,
   deps: [...deps, ...presets.map(p => `node_modules/${p}`), ...plugins.map(p => `node_modules/${p}`), 'node_modules/@babel/core', 'node_modules/@babel/cli'],
@@ -18,7 +18,7 @@ definition = """({ name, targets, deps, env, templateOpts: { presets = [], plugi
     }`
 }, {
   template: 'npm',
-  templateOpts: {
+  options: {
     packages: [...presets.map(p => p.startsWith('@babel/') ? p + '@7' : p), ...plugins.map(p => p.startsWith('@babel/') ? p + '@7' : p), '@babel/core@7', '@babel/cli@7'],
     dev: true
   }

--- a/templates/jspm.toml
+++ b/templates/jspm.toml
@@ -1,6 +1,6 @@
 [[template]]
 name = "jspm"
-definition = """({ name, targets, deps, env, templateOpts: {
+definition = """({ name, targets, deps, env, options: {
   env: generatorEnv = ['browser', 'production', 'module'],
   preload,
   integrity,
@@ -55,7 +55,7 @@ definition = """({ name, targets, deps, env, templateOpts: {
   `
 }, {
   template: 'npm',
-  templateOpts: {
+  options: {
     packages: ['@jspm/generator', 'mkdirp'],
     dev: true
   }

--- a/templates/jspm.toml
+++ b/templates/jspm.toml
@@ -1,6 +1,7 @@
 [[template]]
 name = "jspm"
 definition = """({ name, targets, deps, env, options: {
+  autoInstall,
   env: generatorEnv = ['browser', 'production', 'module'],
   preload,
   integrity,
@@ -56,6 +57,7 @@ definition = """({ name, targets, deps, env, options: {
 }, {
   template: 'npm',
   options: {
+    autoInstall,
     packages: ['@jspm/generator', 'mkdirp'],
     dev: true
   }

--- a/templates/npm.toml
+++ b/templates/npm.toml
@@ -1,6 +1,6 @@
 [[template]]
 name = "npm"
-definition = """({ name, deps, env, options: { packages, dev, pkgManager = 'npm', autoInstall } }) => autoInstall ? [{
+definition = """({ name, deps, env, options: { packages, dev, packageManager = 'npm', autoInstall } }) => autoInstall ? [{
   name,
   deps: [...deps, ...packages.map(pkg => {
     const versionIndex = pkg.indexOf('@', 1);
@@ -14,13 +14,13 @@ definition = """({ name, deps, env, options: { packages, dev, pkgManager = 'npm'
     targetCheck: 'exists',
     deps: ['npm:init'],
     env,
-    run: `${pkgManager} install ${packages.join(' ')}${dev ? ' -D' : ''}`
+    run: `${packageManager} install ${packages.join(' ')}${dev ? ' -D' : ''}`
   };
 }), {
   name: 'npm:init',
   target: 'package.json',
   env,
-  run: `${pkgManager} init -y`
+  run: `${packageManager} init -y`
 }] : [{
   name,
   env,

--- a/templates/npm.toml
+++ b/templates/npm.toml
@@ -1,6 +1,6 @@
 [[template]]
 name = "npm"
-definition = """({ name, deps, env, templateOpts: { packages, dev, pkgManager = 'npm', autoInstall } }) => autoInstall ? [{
+definition = """({ name, deps, env, options: { packages, dev, pkgManager = 'npm', autoInstall } }) => autoInstall ? [{
   name,
   deps: [...deps, ...packages.map(pkg => {
     const versionIndex = pkg.indexOf('@', 1);

--- a/templates/prettier.toml
+++ b/templates/prettier.toml
@@ -1,6 +1,6 @@
 [[template]]
 name = "prettier"
-definition = """({ name, targets, deps, env, templateOpts: { files = '.', check = false, write = true, config = null, noErrorOnUnmatchedPattern = false } }) => [{
+definition = """({ name, targets, deps, env, options: { files = '.', check = false, write = true, config = null, noErrorOnUnmatchedPattern = false } }) => [{
   name,
   targets,
   deps: [...deps, 'node_modules/prettier'],
@@ -16,7 +16,7 @@ definition = """({ name, targets, deps, env, templateOpts: { files = '.', check 
     }`
 }, {
   template: 'npm',
-  templateOpts: {
+  options: {
     packages: ['prettier'],
     dev: true
   }

--- a/templates/prettier.toml
+++ b/templates/prettier.toml
@@ -1,6 +1,6 @@
 [[template]]
 name = "prettier"
-definition = """({ name, targets, deps, env, options: { files = '.', check = false, write = true, config = null, noErrorOnUnmatchedPattern = false } }) => [{
+definition = """({ name, targets, deps, env, options: { files = '.', check = false, write = true, config = null, noErrorOnUnmatchedPattern = false, autoInstall } }) => [{
   name,
   targets,
   deps: [...deps, 'node_modules/prettier'],
@@ -17,6 +17,7 @@ definition = """({ name, targets, deps, env, options: { files = '.', check = fal
 }, {
   template: 'npm',
   options: {
+    autoInstall,
     packages: ['prettier'],
     dev: true
   }

--- a/templates/svelte.toml
+++ b/templates/svelte.toml
@@ -1,6 +1,6 @@
 [[template]]
 name = "svelte"
-definition = """({ name, targets, deps, env, options: { svelteConfig = null } }) => [{
+definition = """({ name, targets, deps, env, options: { svelteConfig = null, autoInstall } }) => [{
   name,
   targets,
   deps: [...deps, 'node_modules/svelte', 'node_modules/mkdirp'],
@@ -37,6 +37,7 @@ definition = """({ name, targets, deps, env, options: { svelteConfig = null } })
 }, {
   template: 'npm',
   options: {
+    autoInstall,
     packages: ['svelte@3', 'mkdirp'],
     dev: true
   }

--- a/templates/svelte.toml
+++ b/templates/svelte.toml
@@ -1,6 +1,6 @@
 [[template]]
 name = "svelte"
-definition = """({ name, targets, deps, env, templateOpts: { svelteConfig = null } }) => [{
+definition = """({ name, targets, deps, env, options: { svelteConfig = null } }) => [{
   name,
   targets,
   deps: [...deps, 'node_modules/svelte', 'node_modules/mkdirp'],
@@ -36,7 +36,7 @@ definition = """({ name, targets, deps, env, templateOpts: { svelteConfig = null
   `
 }, {
   template: 'npm',
-  templateOpts: {
+  options: {
     packages: ['svelte@3', 'mkdirp'],
     dev: true
   }

--- a/templates/swc.toml
+++ b/templates/swc.toml
@@ -1,6 +1,6 @@
 [[template]]
 name = "swc"
-definition = """({ name, targets, deps, env, templateOpts: { configFile = null, swcRc, sourceMaps = true, config = {} } }) => [{
+definition = """({ name, targets, deps, env, options: { configFile = null, swcRc, sourceMaps = true, config = {} } }) => [{
   name,
   targets,
   deps: [...deps, 'node_modules/@swc/core', 'node_modules/@swc/cli'],
@@ -16,7 +16,7 @@ definition = """({ name, targets, deps, env, templateOpts: { configFile = null, 
     }`
 }, {
   template: 'npm',
-  templateOpts: {
+  options: {
     packages: ['@swc/core@1', '@swc/cli@0.1'],
     dev: true
   }

--- a/templates/swc.toml
+++ b/templates/swc.toml
@@ -1,6 +1,6 @@
 [[template]]
 name = "swc"
-definition = """({ name, targets, deps, env, options: { configFile = null, swcRc, sourceMaps = true, config = {} } }) => [{
+definition = """({ name, targets, deps, env, options: { configFile = null, swcRc, sourceMaps = true, config = {}, autoInstall } }) => [{
   name,
   targets,
   deps: [...deps, 'node_modules/@swc/core', 'node_modules/@swc/cli'],
@@ -17,6 +17,7 @@ definition = """({ name, targets, deps, env, options: { configFile = null, swcRc
 }, {
   template: 'npm',
   options: {
+    autoInstall,
     packages: ['@swc/core@1', '@swc/cli@0.1'],
     dev: true
   }

--- a/test/chompfile.toml
+++ b/test/chompfile.toml
@@ -1,6 +1,6 @@
 version = 0.1
 
-[default-template-opts.npm]
+[default-options.npm]
   auto-install = true
 
 [[task]]
@@ -81,5 +81,5 @@ version = 0.1
   template = "babel"
   target = "test-babel.js"
   deps = ["test.ts"]
-  [task.template-opts]
+  [task.options]
     presets = ['@babel/preset-typescript']


### PR DESCRIPTION
This renames the `template-opts` option to just `options`, per discussion in https://github.com/guybedford/chomp/issues/32.

It might make it simpler to just think of this as global default options and task options. The fact that they are applying to and keyed by templates is perhaps less important to highlight than ensuring users just appreciate template tasks take options.

Before:

```toml
[default-template-opts.npm]
  pkg-manager = 'pnpm'

[[task]]
  template = 'svelte'
  [task.template-opts]
    auto-install = true
```

After:

```toml
[default-options.npm]
  package-manager = 'pnpm'

[[task]]
  template = 'svelte'
  [task.options]
    auto-install = true
```