### PR TITLE
options -> template-options, bug fixes

### DIFF
--- a/src/chompfile.rs
+++ b/src/chompfile.rs
@@ -29,7 +29,7 @@ pub struct Chompfile {
     #[serde(default, skip_serializing_if = "is_default")]
     pub template: Vec<ChompTemplate>,
     #[serde(default, skip_serializing_if = "is_default")]
-    pub default_options: BTreeMap<String, BTreeMap<String, toml::value::Value>>,
+    pub template_options: BTreeMap<String, BTreeMap<String, toml::value::Value>>,
 }
 
 #[derive(Debug, Serialize, PartialEq, Deserialize, Clone)]
@@ -77,7 +77,7 @@ pub struct ChompTaskMaybeTemplated {
     pub run: Option<String>,
     pub engine: Option<ChompEngine>,
     pub template: Option<String>,
-    pub options: Option<BTreeMap<String, toml::value::Value>>,
+    pub template_options: Option<BTreeMap<String, toml::value::Value>>,
 }
 
 impl ChompTaskMaybeTemplated {
@@ -112,7 +112,7 @@ pub struct ChompTaskMaybeTemplatedNoDefault {
     pub run: Option<String>,
     pub engine: Option<ChompEngine>,
     pub template: Option<String>,
-    pub options: Option<BTreeMap<String, toml::value::Value>>,
+    pub template_options: Option<BTreeMap<String, toml::value::Value>>,
 }
 
 #[derive(Debug, Serialize, PartialEq, Deserialize)]

--- a/src/templates.toml
+++ b/src/templates.toml
@@ -1,7 +1,7 @@
 ﻿version = 0.1
 [[template]]
 name = "babel"
-definition = """({ name, targets, deps, env, options: { presets = [], plugins = [], sourceMap = true, babelRc = true, configFile = null, autoInstall } }) => [{
+definition = """({ name, targets, deps, env, templateOptions: { presets = [], plugins = [], sourceMap = true, babelRc = true, configFile = null, autoInstall } }) => [{
   name,
   targets,
   deps: [...deps, ...presets.map(p => `node_modules/${p}`), ...plugins.map(p => `node_modules/${p}`), 'node_modules/@babel/core', 'node_modules/@babel/cli'],
@@ -19,16 +19,17 @@ definition = """({ name, targets, deps, env, options: { presets = [], plugins = 
     }`
 }, {
   template: 'npm',
-  options: {
+  templateOptions: {
     packages: [...presets.map(p => p.startsWith('@babel/') ? p + '@7' : p), ...plugins.map(p => p.startsWith('@babel/') ? p + '@7' : p), '@babel/core@7', '@babel/cli@7'],
     dev: true,
-    autoInstall: autoInstall
+    autoInstall
   }
 }];
 """
 [[template]]
 name = "jspm"
-definition = """({ name, targets, deps, env, options: {
+definition = """({ name, targets, deps, env, templateOptions: {
+  autoInstall,
   env: generatorEnv = ['browser', 'production', 'module'],
   preload,
   integrity,
@@ -83,7 +84,8 @@ definition = """({ name, targets, deps, env, options: {
   `
 }, {
   template: 'npm',
-  options: {
+  templateOptions: {
+    autoInstall,
     packages: ['@jspm/generator', 'mkdirp'],
     dev: true
   }
@@ -91,7 +93,7 @@ definition = """({ name, targets, deps, env, options: {
 """
 [[template]]
 name = "npm"
-definition = """({ name, deps, env, options: { packages, dev, packageManager = 'npm', autoInstall } }) => autoInstall ? [{
+definition = """({ name, deps, env, templateOptions: { packages, dev, packageManager = 'npm', autoInstall } }) => autoInstall ? [{
   name,
   deps: [...deps, ...packages.map(pkg => {
     const versionIndex = pkg.indexOf('@', 1);
@@ -124,7 +126,7 @@ definition = """({ name, deps, env, options: { packages, dev, packageManager = '
 """
 [[template]]
 name = "prettier"
-definition = """({ name, targets, deps, env, options: { files = '.', check = false, write = true, config = null, noErrorOnUnmatchedPattern = false } }) => [{
+definition = """({ name, targets, deps, env, templateOptions: { files = '.', check = false, write = true, config = null, noErrorOnUnmatchedPattern = false, autoInstall } }) => [{
   name,
   targets,
   deps: [...deps, 'node_modules/prettier'],
@@ -140,7 +142,8 @@ definition = """({ name, targets, deps, env, options: { files = '.', check = fal
     }`
 }, {
   template: 'npm',
-  options: {
+  templateOptions: {
+    autoInstall,
     packages: ['prettier'],
     dev: true
   }
@@ -148,7 +151,7 @@ definition = """({ name, targets, deps, env, options: { files = '.', check = fal
 """
 [[template]]
 name = "svelte"
-definition = """({ name, targets, deps, env, options: { svelteConfig = null } }) => [{
+definition = """({ name, targets, deps, env, templateOptions: { svelteConfig = null, autoInstall } }) => [{
   name,
   targets,
   deps: [...deps, 'node_modules/svelte', 'node_modules/mkdirp'],
@@ -184,7 +187,8 @@ definition = """({ name, targets, deps, env, options: { svelteConfig = null } })
   `
 }, {
   template: 'npm',
-  options: {
+  templateOptions: {
+    autoInstall,
     packages: ['svelte@3', 'mkdirp'],
     dev: true
   }
@@ -192,7 +196,7 @@ definition = """({ name, targets, deps, env, options: { svelteConfig = null } })
 """
 [[template]]
 name = "swc"
-definition = """({ name, targets, deps, env, options: { configFile = null, swcRc, sourceMaps = true, config = {} } }) => [{
+definition = """({ name, targets, deps, env, templateOptions: { configFile = null, swcRc, sourceMaps = true, config = {}, autoInstall } }) => [{
   name,
   targets,
   deps: [...deps, 'node_modules/@swc/core', 'node_modules/@swc/cli'],
@@ -208,7 +212,8 @@ definition = """({ name, targets, deps, env, options: { configFile = null, swcRc
     }`
 }, {
   template: 'npm',
-  options: {
+  templateOptions: {
+    autoInstall,
     packages: ['@swc/core@1', '@swc/cli@0.1'],
     dev: true
   }

--- a/templates/babel.toml
+++ b/templates/babel.toml
@@ -1,6 +1,6 @@
 [[template]]
 name = "babel"
-definition = """({ name, targets, deps, env, options: { presets = [], plugins = [], sourceMap = true, babelRc = true, configFile = null, autoInstall } }) => [{
+definition = """({ name, targets, deps, env, templateOptions: { presets = [], plugins = [], sourceMap = true, babelRc = true, configFile = null, autoInstall } }) => [{
   name,
   targets,
   deps: [...deps, ...presets.map(p => `node_modules/${p}`), ...plugins.map(p => `node_modules/${p}`), 'node_modules/@babel/core', 'node_modules/@babel/cli'],
@@ -18,7 +18,7 @@ definition = """({ name, targets, deps, env, options: { presets = [], plugins = 
     }`
 }, {
   template: 'npm',
-  options: {
+  templateOptions: {
     packages: [...presets.map(p => p.startsWith('@babel/') ? p + '@7' : p), ...plugins.map(p => p.startsWith('@babel/') ? p + '@7' : p), '@babel/core@7', '@babel/cli@7'],
     dev: true,
     autoInstall

--- a/templates/jspm.toml
+++ b/templates/jspm.toml
@@ -1,6 +1,6 @@
 [[template]]
 name = "jspm"
-definition = """({ name, targets, deps, env, options: {
+definition = """({ name, targets, deps, env, templateOptions: {
   autoInstall,
   env: generatorEnv = ['browser', 'production', 'module'],
   preload,
@@ -56,7 +56,7 @@ definition = """({ name, targets, deps, env, options: {
   `
 }, {
   template: 'npm',
-  options: {
+  templateOptions: {
     autoInstall,
     packages: ['@jspm/generator', 'mkdirp'],
     dev: true

--- a/templates/npm.toml
+++ b/templates/npm.toml
@@ -1,6 +1,6 @@
 [[template]]
 name = "npm"
-definition = """({ name, deps, env, options: { packages, dev, packageManager = 'npm', autoInstall } }) => autoInstall ? [{
+definition = """({ name, deps, env, templateOptions: { packages, dev, packageManager = 'npm', autoInstall } }) => autoInstall ? [{
   name,
   deps: [...deps, ...packages.map(pkg => {
     const versionIndex = pkg.indexOf('@', 1);

--- a/templates/prettier.toml
+++ b/templates/prettier.toml
@@ -1,6 +1,6 @@
 [[template]]
 name = "prettier"
-definition = """({ name, targets, deps, env, options: { files = '.', check = false, write = true, config = null, noErrorOnUnmatchedPattern = false, autoInstall } }) => [{
+definition = """({ name, targets, deps, env, templateOptions: { files = '.', check = false, write = true, config = null, noErrorOnUnmatchedPattern = false, autoInstall } }) => [{
   name,
   targets,
   deps: [...deps, 'node_modules/prettier'],
@@ -16,7 +16,7 @@ definition = """({ name, targets, deps, env, options: { files = '.', check = fal
     }`
 }, {
   template: 'npm',
-  options: {
+  templateOptions: {
     autoInstall,
     packages: ['prettier'],
     dev: true

--- a/templates/svelte.toml
+++ b/templates/svelte.toml
@@ -1,6 +1,6 @@
 [[template]]
 name = "svelte"
-definition = """({ name, targets, deps, env, options: { svelteConfig = null, autoInstall } }) => [{
+definition = """({ name, targets, deps, env, templateOptions: { svelteConfig = null, autoInstall } }) => [{
   name,
   targets,
   deps: [...deps, 'node_modules/svelte', 'node_modules/mkdirp'],
@@ -36,7 +36,7 @@ definition = """({ name, targets, deps, env, options: { svelteConfig = null, aut
   `
 }, {
   template: 'npm',
-  options: {
+  templateOptions: {
     autoInstall,
     packages: ['svelte@3', 'mkdirp'],
     dev: true

--- a/templates/swc.toml
+++ b/templates/swc.toml
@@ -1,6 +1,6 @@
 [[template]]
 name = "swc"
-definition = """({ name, targets, deps, env, options: { configFile = null, swcRc, sourceMaps = true, config = {}, autoInstall } }) => [{
+definition = """({ name, targets, deps, env, templateOptions: { configFile = null, swcRc, sourceMaps = true, config = {}, autoInstall } }) => [{
   name,
   targets,
   deps: [...deps, 'node_modules/@swc/core', 'node_modules/@swc/cli'],
@@ -16,7 +16,7 @@ definition = """({ name, targets, deps, env, options: { configFile = null, swcRc
     }`
 }, {
   template: 'npm',
-  options: {
+  templateOptions: {
     autoInstall,
     packages: ['@swc/core@1', '@swc/cli@0.1'],
     dev: true

--- a/test/chompfile.toml
+++ b/test/chompfile.toml
@@ -1,6 +1,6 @@
 version = 0.1
 
-[default-options.npm]
+[template-options.npm]
   auto-install = true
 
 [[task]]
@@ -81,5 +81,5 @@ version = 0.1
   template = "babel"
   target = "test-babel.js"
   deps = ["test.ts"]
-  [task.options]
+  [task.template-options]
     presets = ['@babel/preset-typescript']


### PR DESCRIPTION
This reverts the change of `template-opts` to `options` to be back to `template-options`, as well as some bug fixes with direct target builds.

The global is now `template-options` as well without the `default`.

BEFORE:

```toml
[default-options.npm]
  package-manager = 'pnpm'

[[task]]
  template = 'swc'
  [task.options]
    auto-install = true
  [task.options.config]
    "jsc.parser.jsx" = true
```

AFTER:
```toml
[template-options.npm]
  package-manager = 'pnpm'

[[task]]
  template = 'swc'
  [task.template-options]
    auto-install = true
  [task.template-options.config]
    "jsc.parser.jsx" = true
```