### PR TITLE
Fixup partial build runs, target normalization

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -144,5 +144,9 @@ async fn main() -> Result<()> {
         cfg_file,
     }).await?;
 
+    if !ok {
+        eprintln!("Unable to complete all tasks.");
+    }
+
     std::process::exit(if ok { 0 } else { 1 });
 }


### PR DESCRIPTION
This fixes partial runs, for example just running a few builds out of an interpolation instead of triggering them all. This ensures we only ever do the absolutely necessary work to complete the tasks requested and no more.