### PR TITLE
feat: unit testing pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ test/test-babel.js
 test/test-babel.js.map
 test/.babelrc
 test/.swcrc
+test/testlog.txt

--- a/test/chompfile.toml
+++ b/test/chompfile.toml
@@ -14,7 +14,7 @@ extensions = [
 [[task]]
   name = "test"
   serial = true
-  deps = ["test:init", "fail", "prettier", "jspm", "svelte", "swc", "babel", "check"]
+  deps = ["test:init", "fail", "prettier", "jspm", "svelte", "swc", "babel", "unit", "check"]
 
 [[task]]
   name = "fail"
@@ -22,6 +22,11 @@ extensions = [
     chomp test:fail
     echo "recover"
   """
+
+[[task]]
+  name = "unit"
+  dep = "unit/#.js"
+  run = "node $DEP >> testlog.txt"
 
 # verify that a serial failure stops the build and logs correctly
 [[task]]
@@ -41,15 +46,23 @@ extensions = [
 [[task]]
   name = "check"
   deps = ["app-build.html", "test.js"]
-  run = """
-    echo \"TESTS OK\" >> testlog.txt
-    cat testlog.txt
-    rm testlog.txt
-  """
+  engine = "node"
+  run = '''
+    import { readFileSync } from 'fs';
+    import assert from 'assert';
+
+    const log = readFileSync('testlog.txt', 'utf8').trim().split(/\r?\n/);
+    assert.equal(log.length, 2);
+    assert(log.indexOf('unit test a') !== -1);
+    assert(log.indexOf('unit test b') !== -1);
+
+    console.log('TESTS OK');
+  '''
 
 [[task]]
   name = "test:init"
   run = """
+    rm testlog.txt
     rm -r node_modules
     rm package.json
     rm package-lock.json

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,1 +1,1 @@
-﻿export var p: number = 5;
+export var p: number = 5;

--- a/test/unit/testa.js
+++ b/test/unit/testa.js
@@ -1,0 +1,1 @@
+console.log("unit test a");

--- a/test/unit/testb.js
+++ b/test/unit/testb.js
@@ -1,0 +1,1 @@
+console.log("unit test b");


### PR DESCRIPTION
This creates a pattern for defining tasks as unit tests, using interpolation to iterate over the tests, even though there is no task target - a really nice way to setup testing in a codebase!

Example:

```toml
[[task]]
name = "test:unit"
dep = "unit/#.js"
run = "node $DEP"
```

With this pattern `chomp test:unit` is a full unit test runner, and displays ticks and crosses since all tasks are already based on being either an error or a success. By default unit tests will run in parallel, and setting `serial = true` will run unit tests serially. All within the same simple task system.