### PR TITLE
Handle missing Deno / Node engines

### DIFF
--- a/src/engines/deno.rs
+++ b/src/engines/deno.rs
@@ -8,7 +8,6 @@ use tokio::fs;
 use std::env;
 use uuid::Uuid;
 use futures::future::{FutureExt};
-use crate::chompfile::ChompEngine;
 
 const DENO_CMD: &str = "deno run -A --unstable --no-check $CHOMP_MAIN";
 
@@ -29,15 +28,17 @@ pub fn deno_runner(
   let targets = targets.clone();
   let write_future = fs::write(tmp_file, cmd.run.to_string());
   cmd.run = DENO_CMD.to_string();
-  cmd.engine = ChompEngine::Cmd;
   let exec_num = cmd_pool.exec_num;
   cmd_pool.exec_cnt = cmd_pool.exec_cnt + 1;
   let pool = cmd_pool as *mut CmdPool;
-  let child = create_cmd(cmd.cwd.as_ref().unwrap_or(&cmd_pool.cwd), &cmd, debug);
+  let child = create_cmd(cmd.cwd.as_ref().unwrap_or(&cmd_pool.cwd), &cmd, debug, false);
   let future = async move {
     let cmd_pool = unsafe { &mut *pool };
     let mut exec = &mut cmd_pool.execs.get_mut(&exec_num).unwrap();
     write_future.await.expect("unable to write temporary file");
+    if exec.child.is_none() {
+      return None;
+    }
     exec.state = match exec.child.as_mut().unwrap().wait().await {
       Ok(status) => {
           if status.success() {
@@ -56,10 +57,9 @@ pub fn deno_runner(
     let end_time = Instant::now();
     // finally we verify that the targets exist
     let mtime = check_target_mtimes(targets, true).await;
-    (exec.state, mtime, end_time - start_time)
+    Some((exec.state, mtime, end_time - start_time))
   }.boxed_local().shared();
 
-  cmd_pool.execs.insert(exec_num, Exec { cmd, child: Some(child), future, state: ExecState::Executing });
+  cmd_pool.execs.insert(exec_num, Exec { cmd, child, future, state: ExecState::Executing });
   cmd_pool.exec_num = cmd_pool.exec_num + 1;
-
 }

--- a/src/engines/node.rs
+++ b/src/engines/node.rs
@@ -8,7 +8,6 @@ use tokio::fs;
 use std::env;
 use uuid::Uuid;
 use futures::future::{FutureExt};
-use crate::chompfile::ChompEngine;
 
 // Custom node loader to mimic current working directory despite loading from a tmp file
 const NODE_CMD: &str = "node --no-warnings --loader \"data:text/javascript,import{readFileSync}from'fs';export function resolve(u,c,d){if(u.endsWith('[cm]'))return{url:u,format:'module'};return d(u,c);}export function load(u,c,d){if(u.endsWith('[cm]'))return{source:readFileSync(process.env.CHOMP_MAIN),format:'module'};return d(u,c)}export{load as getFormat,load as getSource}\" [cm]";
@@ -30,15 +29,17 @@ pub fn node_runner(
   let targets = targets.clone();
   let write_future = fs::write(tmp_file, cmd.run.to_string());
   cmd.run = NODE_CMD.to_string();
-  cmd.engine = ChompEngine::Cmd;
   let exec_num = cmd_pool.exec_num;
   cmd_pool.exec_cnt = cmd_pool.exec_cnt + 1;
   let pool = cmd_pool as *mut CmdPool;
-  let child = create_cmd(cmd.cwd.as_ref().unwrap_or(&cmd_pool.cwd), &cmd, debug);
+  let child = create_cmd(cmd.cwd.as_ref().unwrap_or(&cmd_pool.cwd), &cmd, debug, false);
   let future = async move {
     let cmd_pool = unsafe { &mut *pool };
     let mut exec = &mut cmd_pool.execs.get_mut(&exec_num).unwrap();
     write_future.await.expect("unable to write temporary file");
+    if exec.child.is_none() {
+      return None;
+    }
     exec.state = match exec.child.as_mut().unwrap().wait().await {
       Ok(status) => {
           if status.success() {
@@ -57,10 +58,9 @@ pub fn node_runner(
     let end_time = Instant::now();
     // finally we verify that the targets exist
     let mtime = check_target_mtimes(targets, true).await;
-    (exec.state, mtime, end_time - start_time)
+    Some((exec.state, mtime, end_time - start_time))
   }.boxed_local().shared();
 
-  cmd_pool.execs.insert(exec_num, Exec { cmd, child: Some(child), future, state: ExecState::Executing });
+  cmd_pool.execs.insert(exec_num, Exec { cmd, child, future, state: ExecState::Executing });
   cmd_pool.exec_num = cmd_pool.exec_num + 1;
-
 }


### PR DESCRIPTION
This improves the engine handling to throw nice error message when Deno or Node.js is not installed and we are using these engines.

Fixes https://github.com/guybedford/chomp/issues/55.

Example error message:

```
chomp swc:init
🞂 :swc:init
Error: Exec error: Unable to initialize the Deno Chomp engine.
Make sure Deno is correctly installed and the deno bin is in the environment PATH.

See https://deno.land/#installation
```