### PR TITLE
Feat: `chomp --init` and `chomp --import-scripts`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,6 +149,7 @@ dependencies = [
  "num_cpus",
  "regex",
  "serde",
+ "serde_json",
  "serde_v8",
  "sha2",
  "tokio",
@@ -1060,6 +1061,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1134,6 +1141,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ notify = "4.0.17"
 num_cpus = "1.13.0"
 regex = "1.5"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 serde_v8 = "0.22.0"
 sha2 = "0.10.1"
 tokio = { version = "1", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Then use `chomp <name>` instead of `npm run <name>`, and enjoy the new features 
 
 ### Hello World
 
-`chomp` works against a `chompfile.toml` in the same directory as the `chomp` command is run.
+`chomp` works against a `chompfile.toml` [TOML configuration](https://toml.io/) in the same directory as the `chomp` command is run.
 
 For example:
 
@@ -111,6 +111,8 @@ Hello Chomp
 Array `deps` can be defined for targets, whose targets will then be run first with invalidation based on target / deps mtime comparisons per the standard Makefile approach.
 
 In Windows, Powershell is used and Bash on posix systems. Since both `echo` and `>` are defined on both systems the above works cross-platform (Powershell is automatically put into UTF-8 mode for `>` to work similarly).
+
+Note that `&&` and `||` are not supported in Powershell, so multiline scripts and `;` are preferred instead.
 
 Alternatively use `engine = 'node'` or `engine = 'deno'` to write JavaScript in the `run` function instead:
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,24 @@ cargo install chompbuild
 
 ## Getting Started
 
+### Migrating from npm Scripts
+
+To convert an existing project using npm `"scripts"` to Chomp, run:
+
+```sh
+$ chomp --init --import-scripts
+√ chompfile.toml created with 2 package.json script tasks imported.
+```
+
+or the shorter version:
+
+```sh
+$ chomp -Ii
+√ chompfile.toml created with 2 package.json script tasks imported.
+```
+
+Then use `chomp <name>` instead of `npm run <name>`, and enjoy the new features of task dependence, incremental builds and parallelism!
+
 ### Hello World
 
 `chomp` works against a `chompfile.toml` in the same directory as the `chomp` command is run.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -15,6 +15,8 @@ Chomp takes the following arguments and flags:
 * [`-f, --force`](#force): Force rebuild targets
 * [`-F, --format`](#format): Format and save the chompfile.toml
 * [`-h, --help`](#help): Prints help information
+* [`-I, --import-scripts`](#import-scripts): Import npm package.json "scripts" into the chompfile.toml
+* [`-i, --init`](#init): Initialize the chompfile.toml if it does not exist
 * [`-j, --jobs`](#jobs): Maximum number of jobs to run in parallel
 * [`-l, --list`](#list): List the available chompfile tasks
 * [`-p, --port`](#port): Custom port to serve

--- a/docs/task.md
+++ b/docs/task.md
@@ -85,7 +85,7 @@ $ chomp my-task
 
 The default `engine` is the shell environment - PowerShell on Windows or `sh` on posix machines.
 
-Common commands like `echo`, `pwd`, `cat`, `rm`, `cp`, `cd`, as well as operators like `$(cmd)`, `>`, `>>`, `|` form a subset of shared behaviours that can work when scripting between all platforms. With some care and testing, it is possible to write cross-platform shell task scripts. For PowerShell 5, Chomp will execute PowerShell in UTF-8 mode (applying to `>`, `>>` and `|`), although a BOM will still be output when writing a new file with `>`.
+Common commands like `echo`, `pwd`, `cat`, `rm`, `cp`, `cd`, as well as operators like `$(cmd)`, `>`, `>>`, `|` form a subset of shared behaviours that can work when scripting between all platforms. With some care and testing, it is possible to write cross-platform shell task scripts. For PowerShell 5, Chomp will execute PowerShell in UTF-8 mode (applying to `>`, `>>` and `|`), although a BOM will still be output when writing a new file with `>`. Since `&&` and `||` are not supported in Powershell, multiline scripts and `;` are preferred instead.
 
 For example, here is an SWC task (assuming Babel is installed via `npm install @swc/core @swc/cli -D`):
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -131,11 +131,13 @@ async fn main() -> Result<()> {
         )
         .arg(
             Arg::with_name("init")
+                .short("i")
                 .long("init")
                 .help("Initialize a new chompfile.toml if it does not exist"),
         )
         .arg(
             Arg::with_name("import_scripts")
+                .short("I")
                 .long("import-scripts")
                 .help("Import from npm \"scripts\" into the chompfile.toml"),
         )


### PR DESCRIPTION
This PR provides two new features:

1. `chomp --init` / `chomp -i` will create `chompfile.toml` if it does not already exist.
2. `chomp --import-scripts` / `chomp -I` will import package.json "scripts" from an npm workflow prepopulating these into the associated Chomp tasks so that `npm run build` can be migrated to `chomp build` as simply as `chomp --import-scripts build`.

Associated documentation is provided.