### PR TITLE
feat: static environment variable replacements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chompbuild"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/docs/task.md
+++ b/docs/task.md
@@ -35,6 +35,7 @@ Tasks support the following optional properties:
 * **cwd**: `String`, the working directory to use for the `engine` execution.
 * **env**: `{ [key: String]: String }`, custom environment variables to set for the `engine` execution.
 * **env-default**: `{ [key: String]: String }`, custom default environment variables to set for the `engine` execution, only if not already present in the system environment.
+* **env-replace**: `Boolean`, defaults to `true`. Whether to support `${{VAR}}` style static environment variable replacements in the `env` and `env-default` environment variable declarations.
 * **template**: `String`, a registered template name to use for task generation as a [template task](#extensions).
 * **template-options**: `{ [option: String]: any }`, the dictionary of options to apply to the `template` [template generation](#extensions), as defined by the template itself.
 
@@ -119,6 +120,8 @@ In addition to the `run` property, two other useful task properties are `env` an
 
 In PowerShell, defined environment variables in the task `env` are in addition made available as local variables supporting output via `$NAME` instead of `$Env:Name` for better cross-compatibility with posix shells. This process is explicit only - system-level environment variables are not given this treatment though.
 
+In addition, static environment variable replacements are available via `${{VAR}}`, with optional spacing. Replacements that cannot be resolved to a known environment variable will be replaced with an empty string. Static replacements are available for environment variables and the shell engine run command. Set `env-replace = false` to disable static environment variable replacement for a given task.
+
 _chompfile.toml_
 ```toml
 version = 0.1
@@ -126,20 +129,19 @@ version = 0.1
 [[task]]
 name = 'env-vars'
 run = '''
-  echo $VAR1 $VAR2
+  ${{ECHO}} $PARAM1 $PARAM2
 '''
 [task.env]
-VAR1 = 'Chomp'
+PARAM1 = 'Chomp'
 
 [task.default-env]
-VAR2 = '$VAR1'
+ECHO = 'echo'
+PARAM2 = '${{ PARAM1 }}'
 ```
 
-_<div style="text-align: center">Custom environment variables are also exposed as local variables in PowerShell.</div>_
+_<div style="text-align: center">Custom environment variables are also exposed as local variables in PowerShell, while `${{VAR}}` provides static replacements.</div>_
 
-On both Posix and Windows, `chomp env-vars` will output: `Chomp Chomp`.
-
-`VAR2 = "$VAR1"` works as a convenience feature in Chomp for substituting environment variables in other environment variables.
+On both Posix and Windows, `chomp env-vars` will output: `Chomp Chomp`, unless the system has overrides of the `CMD` or `PARAM2` environment variables to alternative values.
 
 `default-env` permits the definition of default environment variables which are only set to the default values if these environment variables are not already set in the system environment or via the global Chompfile environment variables. Just like `env`, all variables in `default-env` are also defined as PowerShell local variables, even when they are already set in the environment and the default does not apply.
 

--- a/docs/task.md
+++ b/docs/task.md
@@ -35,7 +35,7 @@ Tasks support the following optional properties:
 * **cwd**: `String`, the working directory to use for the `engine` execution.
 * **env**: `{ [key: String]: String }`, custom environment variables to set for the `engine` execution.
 * **env-default**: `{ [key: String]: String }`, custom default environment variables to set for the `engine` execution, only if not already present in the system environment.
-* **env-replace**: `Boolean`, defaults to `true`. Whether to support `${{VAR}}` style static environment variable replacements in the `env` and `env-default` environment variable declarations.
+* **env-replace**: `Boolean`, defaults to `true`. Whether to support `${{VAR}}` style static environment variable replacements in the `env` and `env-default` environment variable declarations and the `run` script of Shell engine tasks.
 * **template**: `String`, a registered template name to use for task generation as a [template task](#extensions).
 * **template-options**: `{ [option: String]: any }`, the dictionary of options to apply to the `template` [template generation](#extensions), as defined by the template itself.
 

--- a/src/chompfile.rs
+++ b/src/chompfile.rs
@@ -130,6 +130,7 @@ pub struct ChompTaskMaybeTemplated {
     pub engine: Option<ChompEngine>,
     pub run: Option<String>,
     pub cwd: Option<String>,
+    pub env_replace: Option<bool>,
     pub template: Option<String>,
     pub template_options: Option<HashMap<String, toml::value::Value>>,
     #[serde(default, skip_serializing_if = "is_default")]
@@ -212,6 +213,7 @@ pub struct ChompTaskMaybeTemplatedNoDefault {
     pub engine: Option<ChompEngine>,
     pub run: Option<String>,
     pub cwd: Option<String>,
+    pub env_replace: Option<bool>,
     pub template: Option<String>,
     pub template_options: Option<HashMap<String, toml::value::Value>>,
     pub env: Option<HashMap<String, String>>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -419,6 +419,7 @@ async fn main() -> Result<()> {
                                     target: None,
                                     display: None,
                                     engine: None,
+                                    env_replace: None,
                                     env: HashMap::new(),
                                     env_default: HashMap::new(),
                                     invalidation: None,

--- a/src/task.rs
+++ b/src/task.rs
@@ -49,7 +49,7 @@ use derivative::Derivative;
 use futures::executor;
 use tokio::fs;
 use tokio::time;
-use crate::engines::replace_env_vars;
+use crate::engines::replace_env_vars_static;
 
 use notify::{watcher, RecursiveMode, Watcher};
 use std::sync::mpsc::channel;
@@ -65,6 +65,7 @@ pub struct Task {
     display: Option<TaskDisplay>,
     stdio: TaskStdio,
     env: BTreeMap<String, String>,
+    env_replace: bool,
     cwd: Option<String>,
     run: Option<String>,
     engine: ChompEngine,
@@ -405,6 +406,7 @@ pub fn expand_template_tasks(
             display: task.display,
             stdio: Some(task.stdio.unwrap_or_default()),
             serial: task.serial,
+            env_replace: task.env_replace,
             env: Some(task.env),
             env_default: Some(task.env_default),
             run: task.run,
@@ -466,6 +468,7 @@ pub fn expand_template_tasks(
                 dep,
                 deps,
                 serial: template_task.serial,
+                env_replace: template_task.env_replace,
                 env: template_task.env.unwrap_or_default(),
                 env_default: template_task.env_default.unwrap_or_default(),
                 run: template_task.run,
@@ -491,14 +494,14 @@ fn now () -> std::time::Duration {
 // env vars since these are specifically promoted to local variables
 // for the powershell exec
 #[cfg(target_os = "windows")]
-fn create_task_env (task: &impl ChompTask, chompfile: &Chompfile) -> BTreeMap<String, String> {
+fn create_task_env (task: &impl ChompTask, chompfile: &Chompfile, replacements: bool) -> BTreeMap<String, String> {
     let mut env = BTreeMap::new();
     for (item, value) in &chompfile.env {
-        env.insert(item.to_uppercase(), replace_env_vars(value, &env));
+        env.insert(item.to_uppercase(), if replacements { replace_env_vars_static(value, &env) } else { value.to_string() });
     }
     if let Some(task_env) = task.env() {
         for (item, value) in task_env {
-            env.insert(item.to_uppercase(), replace_env_vars(value, &env));
+            env.insert(item.to_uppercase(), if replacements { replace_env_vars_static(value, &env) } else { value.to_string() });
         }
     }
     if let Some(task_env_default) = task.env_default() {
@@ -507,7 +510,7 @@ fn create_task_env (task: &impl ChompTask, chompfile: &Chompfile) -> BTreeMap<St
                 if let Some(val) = std::env::var_os(item) {
                     env.insert(item.to_uppercase(), String::from(val.to_str().unwrap()));
                 } else {
-                    env.insert(item.to_uppercase(), replace_env_vars(value, &env));
+                    env.insert(item.to_uppercase(), if replacements { replace_env_vars_static(value, &env) } else { value.to_string() });
                 }
             }
         }
@@ -517,7 +520,7 @@ fn create_task_env (task: &impl ChompTask, chompfile: &Chompfile) -> BTreeMap<St
             if let Some(val) = std::env::var_os(item) {
                 env.insert(item.to_uppercase(), String::from(val.to_str().unwrap()));
             } else {
-                env.insert(item.to_uppercase(), replace_env_vars(value, &env));
+                env.insert(item.to_uppercase(), if replacements { replace_env_vars_static(value, &env) } else { value.to_string() });
             }
         }
     }
@@ -525,26 +528,26 @@ fn create_task_env (task: &impl ChompTask, chompfile: &Chompfile) -> BTreeMap<St
 }
 
 #[cfg(not(target_os = "windows"))]
-fn create_task_env (task: &impl ChompTask, chompfile: &Chompfile) -> BTreeMap<String, String> {
+fn create_task_env (task: &impl ChompTask, chompfile: &Chompfile, replacements: bool) -> BTreeMap<String, String> {
     let mut env = BTreeMap::new();
     for (item, value) in &chompfile.env {
-        env.insert(item.to_uppercase(), replace_env_vars(value, &env));
+        env.insert(item.to_uppercase(), if replacements { replace_env_vars(value, &env) } else { value.to_string() });
     }
     if let Some(task_env) = task.env() {
         for (item, value) in task_env {
-            env.insert(item.to_uppercase(), replace_env_vars(value, &env));
+            env.insert(item.to_uppercase(), if replacements { replace_env_vars(value, &env) } else { value.to_string() });
         }
     }
     if let Some(task_env_default) = task.env_default() {
         for (item, value) in task_env_default {
             if !env.contains_key(item) && std::env::var_os(item).is_none() {
-                env.insert(item.to_uppercase(), replace_env_vars(value, &env));
+                env.insert(item.to_uppercase(), if replacements { replace_env_vars(value, &env) } else { value.to_string() });
             }
         }
     }
     for (item, value) in &chompfile.env_default {
         if !env.contains_key(item) && std::env::var_os(item).is_none() {
-            env.insert(item.to_uppercase(), replace_env_vars(value, &env));
+            env.insert(item.to_uppercase(), if replacements { replace_env_vars(value, &env) } else { value.to_string() });
         }
     }
     env
@@ -589,7 +592,7 @@ impl<'a> Runner<'a> {
         for task in template_tasks.drain(..) {
             let targets = task.targets_vec();
             let deps = task.deps_vec();
-            let env = create_task_env(&task, &chompfile);
+            let env = create_task_env(&task, &chompfile, task.env_replace.unwrap_or(true));
             let task = Task {
                 name: task.name,
                 targets,
@@ -600,6 +603,7 @@ impl<'a> Runner<'a> {
                 stdio: task.stdio.unwrap_or_default(),
                 engine: task.engine.unwrap_or_default(),
                 env,
+                env_replace: task.env_replace.unwrap_or(true),
                 run: task.run.clone(),
                 cwd: task.cwd,
                 invalidation: task.invalidation.unwrap_or_default(),
@@ -612,7 +616,7 @@ impl<'a> Runner<'a> {
         for task in tasks.drain(..) {
             let targets = task.targets_vec();
             let deps = task.deps_vec();
-            let env = create_task_env(&task, &chompfile);
+            let env = create_task_env(&task, &chompfile, task.env_replace.unwrap_or(true));
             let task = Task {
                 name: task.name,
                 targets,
@@ -623,6 +627,7 @@ impl<'a> Runner<'a> {
                 stdio: task.stdio.unwrap_or_default(),
                 engine: task.engine.unwrap_or_default(),
                 env,
+                env_replace: task.env_replace.unwrap_or(true),
                 run: task.run.clone(),
                 cwd: task.cwd,
                 invalidation: task.invalidation.unwrap_or_default(),
@@ -1037,6 +1042,7 @@ impl<'a> Runner<'a> {
 
         let targets = job.targets.clone();
         let engine = task.engine;
+        let env_replace = task.env_replace;
         let debug = self.chompfile.debug;
         let cmd_num = {
             let stdio = task.stdio;
@@ -1071,7 +1077,7 @@ impl<'a> Runner<'a> {
                 },
                 None => None
             };
-            let cmd_num = self.cmd_pool.batch(display_name, run, targets, env, cwd, engine, stdio);
+            let cmd_num = self.cmd_pool.batch(display_name, run, targets, env, env_replace, cwd, engine, stdio);
             let job = self.get_job_mut(job_num).unwrap();
             job.state = JobState::Running;
             job.cmd_num = Some(cmd_num);

--- a/src/task.rs
+++ b/src/task.rs
@@ -531,23 +531,23 @@ fn create_task_env (task: &impl ChompTask, chompfile: &Chompfile, replacements: 
 fn create_task_env (task: &impl ChompTask, chompfile: &Chompfile, replacements: bool) -> BTreeMap<String, String> {
     let mut env = BTreeMap::new();
     for (item, value) in &chompfile.env {
-        env.insert(item.to_uppercase(), if replacements { replace_env_vars(value, &env) } else { value.to_string() });
+        env.insert(item.to_uppercase(), if replacements { replace_env_vars_static(value, &env) } else { value.to_string() });
     }
     if let Some(task_env) = task.env() {
         for (item, value) in task_env {
-            env.insert(item.to_uppercase(), if replacements { replace_env_vars(value, &env) } else { value.to_string() });
+            env.insert(item.to_uppercase(), if replacements { replace_env_vars_static(value, &env) } else { value.to_string() });
         }
     }
     if let Some(task_env_default) = task.env_default() {
         for (item, value) in task_env_default {
             if !env.contains_key(item) && std::env::var_os(item).is_none() {
-                env.insert(item.to_uppercase(), if replacements { replace_env_vars(value, &env) } else { value.to_string() });
+                env.insert(item.to_uppercase(), if replacements { replace_env_vars_static(value, &env) } else { value.to_string() });
             }
         }
     }
     for (item, value) in &chompfile.env_default {
         if !env.contains_key(item) && std::env::var_os(item).is_none() {
-            env.insert(item.to_uppercase(), if replacements { replace_env_vars(value, &env) } else { value.to_string() });
+            env.insert(item.to_uppercase(), if replacements { replace_env_vars_static(value, &env) } else { value.to_string() });
         }
     }
     env

--- a/test/chompfile.toml
+++ b/test/chompfile.toml
@@ -34,15 +34,16 @@ name = 'test2'
 display = 'none'
 target = 'output/test2.txt'
 run = '''
-  echo "$VAR $ANOTHER" > $TARGET
+  ${{ECHO}} "$VAR $ANOTHER" > $TARGET
 '''
 template = 'assert'
 [task.env]
 VAR = 'Chomp'
+ECHO = 'echo'
 [task.env-default]
-ANOTHER = '$VAR MM'
+ANOTHER = '${{VAR}} ${{UNKNOWN}} ${{ VAR }} ${{--INVALID--}} $NOREPLACE MM'
 [task.template-options]
-expect-equals = 'Chomp Chomp MM'
+expect-equals = 'Chomp Chomp  Chomp  $NOREPLACE MM'
 
 # -- Test --
 [[task]]


### PR DESCRIPTION
Runtime environment variable usage via `$VAR` works well in most cases, but has limitations when it comes to for example executing a command at a path, where `$VAR/bin/app` isn't supported in Powershell so there's no cross-platform way to do this.

This adds `${{VAR}}` static replacements, and uses these for environment variable replacements in environment variables themselves as well as for the `run` script of Shell tasks only.

A new option `env-replacements = false` can be used to disable this per-task in the rare case of conflict.

Any `${{..}}` which cannot be resolved will be replaced with the empty string, so in theory we could extend the syntax to basic execution syntax in future, but for now it's just direct variable replacements only. The use of `$VAR` replacements in environment variables is fully deprecated and replaced with this new static syntax.