### PR TITLE
feat: chomp --rerun as --force alternative

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -20,8 +20,9 @@ Chomp takes the following arguments and flags:
 * [`-j, --jobs`](#jobs): Maximum number of jobs to run in parallel
 * [`-l, --list`](#list): List the available chompfile tasks
 * [`-p, --port`](#port): Custom port to serve
+* [`-r, --rerun`](#rerun): Rerun the listed targets without caching
 * [`-s, --serve`](#serve): Run a local dev server
-* [`-r, --server-root`](#server-root): Server root path
+* [`-R, --server-root`](#server-root): Server root path
 * [`-V, --version`](#version): Prints version information
 * [`-w, --watch`](#watch): Watch the input files for changes
 
@@ -88,6 +89,12 @@ By default tasks in Chomp are run with [maximum parallelization](task.md#task-pa
 ## Port
 
 When using [`chomp --serve`](#serve) to run a local static server, customizes the static server port. Defaults to `8080`.
+
+## Rerun
+
+Useful to rerun specific tasks without caching without invalidating the whole tree.
+
+To invalidate the full task graph use [`chomp --force`](#force).
 
 ## Serve
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,7 +82,7 @@ async fn main() -> Result<()> {
         )
         .arg(
             Arg::with_name("server-root")
-                .short("r")
+                .short("R")
                 .long("server-root")
                 .help("Server root path")
                 .takes_value(true),
@@ -146,6 +146,12 @@ async fn main() -> Result<()> {
                 .short("C")
                 .long("clear-cache")
                 .help("Clear URL extension cache"),
+        )
+        .arg(
+            Arg::with_name("rerun")
+                .short("r")
+                .long("rerun")
+                .help("Rerun the target tasks even if cached"),
         )
         .arg(
             Arg::with_name("force")
@@ -475,6 +481,7 @@ async fn main() -> Result<()> {
         task::RunOptions {
             watch: matches.is_present("serve") || matches.is_present("watch"),
             force: matches.is_present("force"),
+            rerun: matches.is_present("rerun"),
             args: if args.len() > 0 { Some(args) } else { None },
             pool_size,
             targets,

--- a/src/task.rs
+++ b/src/task.rs
@@ -1029,7 +1029,7 @@ impl<'a> Runner<'a> {
         }
         // If we have an mtime, check if we need to do work
         if let Some(mtime) = job.mtime {
-            let can_skip = !force && mtime.as_secs() > 0
+            let can_skip = !force
                 && task.args.is_none()
                 && match task.invalidation {
                     InvalidationCheck::NotFound => true,
@@ -2239,7 +2239,7 @@ pub async fn run<'a>(
         for job in jobs {
             if opts.rerun {
                 let mut job = runner.get_job_mut(job).unwrap();
-                job.mtime = Some(Duration::new(0, 0));
+                job.mtime = None;
                 job.state = JobState::Pending;
             }
             job_nums.insert(job);

--- a/test/chompfile.toml
+++ b/test/chompfile.toml
@@ -152,4 +152,4 @@ deps = ['fixtures/src/**/*.ts', 'build:swc']
 run = 'echo "$DEPS" > output/deps.txt'
 template = 'assert'
 [task.template-options]
-expect-equals = 'fixtures/src/app.ts:fixtures/src/dep.ts:output/lib/app.js:output/lib/dep.js'
+expect-match = 'fixtures/src/(app|dep)\.ts:fixtures/src/(app|dep)\.ts:output/lib/app.js:output/lib/dep.js'


### PR DESCRIPTION
This adds a new flag `chomp -r` or `chomp --rerun` to just rerun the top-level task that is requested.

When developing tasks, this is useful to avoid a full `--force` build which will invalidate everything and instead just rebuild the task that is being specified by the user while keeping the rest of the cache.