### PR TITLE
fix: match targets and deps separators

### DIFF
--- a/docs/task.md
+++ b/docs/task.md
@@ -148,7 +148,7 @@ On both Posix and Windows, `chomp env-vars` will output: `Chomp Chomp`, unless t
 The following task-level environment variables are always defined:
 
 * `TARGET`: The path to the primary target (the interpolation target or first target).
-* `TARGETS`: The comma-separated list of target paths for multiple targets.
+* `TARGETS`: The `:`-separated list of target paths for multiple targets.
 * `DEP`: The path to the primary dependency (the interpolation dependency or first dependency file).
 * `DEPS`: The `:`-separated list of expanded dependency paths.
 * `MATCH` When using [task interpolation](#task-interpolation) this provides the matched interpolation replacement value (although the `TARGET` will always be the fully substituted interpolation target for interpolation tasks).

--- a/src/task.rs
+++ b/src/task.rs
@@ -1142,7 +1142,7 @@ impl<'a> Runner<'a> {
         let mut targets = String::new();
         for (idx, t) in task.targets.iter().enumerate() {
             if idx > 0 {
-                targets.push_str(",");
+                targets.push_str(":");
             }
             if idx == target_index {
                 targets.push_str(&target);


### PR DESCRIPTION
This updates the `TARGETS` environment variable to be `:` separated like `DEPS` instead of comma separated.