### PR TITLE
Fix: Env override ordering

### DIFF
--- a/src/task.rs
+++ b/src/task.rs
@@ -532,6 +532,22 @@ fn create_task_env(
             },
         );
     }
+    for (item, value) in &chompfile.env_default {
+        if !env.contains_key(item) {
+            if let Some(val) = std::env::var_os(item) {
+                env.insert(item.to_uppercase(), String::from(val.to_str().unwrap()));
+            } else {
+                env.insert(
+                    item.to_uppercase(),
+                    if replacements {
+                        replace_env_vars_static(value, &env)
+                    } else {
+                        value.to_string()
+                    },
+                );
+            }
+        }
+    }
     if let Some(task_env) = task.env() {
         for (item, value) in task_env {
             env.insert(
@@ -562,22 +578,6 @@ fn create_task_env(
             }
         }
     }
-    for (item, value) in &chompfile.env_default {
-        if !env.contains_key(item) {
-            if let Some(val) = std::env::var_os(item) {
-                env.insert(item.to_uppercase(), String::from(val.to_str().unwrap()));
-            } else {
-                env.insert(
-                    item.to_uppercase(),
-                    if replacements {
-                        replace_env_vars_static(value, &env)
-                    } else {
-                        value.to_string()
-                    },
-                );
-            }
-        }
-    }
     env
 }
 
@@ -597,6 +597,18 @@ fn create_task_env(
                 value.to_string()
             },
         );
+    }
+    for (item, value) in &chompfile.env_default {
+        if !env.contains_key(item) && std::env::var_os(item).is_none() {
+            env.insert(
+                item.to_uppercase(),
+                if replacements {
+                    replace_env_vars_static(value, &env)
+                } else {
+                    value.to_string()
+                },
+            );
+        }
     }
     if let Some(task_env) = task.env() {
         for (item, value) in task_env {
@@ -622,18 +634,6 @@ fn create_task_env(
                     },
                 );
             }
-        }
-    }
-    for (item, value) in &chompfile.env_default {
-        if !env.contains_key(item) && std::env::var_os(item).is_none() {
-            env.insert(
-                item.to_uppercase(),
-                if replacements {
-                    replace_env_vars_static(value, &env)
-                } else {
-                    value.to_string()
-                },
-            );
         }
     }
     env

--- a/test/chompfile.toml
+++ b/test/chompfile.toml
@@ -2,6 +2,12 @@ version = 0.1
 extensions = ['chomp@0.1:assert', 'chomp@0.1:npm']
 default-task = 'test'
 
+[env]
+VAL = 'C'
+
+[env-default]
+DEFAULT = '${{ VAL }}H'
+
 [[task]]
 name = 'test'
 serial = true
@@ -38,12 +44,12 @@ run = '''
 '''
 template = 'assert'
 [task.env]
-VAR = 'Chomp'
+VAR = 'Chomp ${{ DEFAULT }}'
 ECHO = 'echo'
 [task.env-default]
-ANOTHER = '${{VAR}} ${{UNKNOWN}} ${{ VAR }} ${{--INVALID--}} $NOREPLACE MM'
+ANOTHER = '${{VAR}} ${{UNKNOWN}} ${{ VAR }} ${{--INVALID--}} $NOREPLACE ${{ DEFAULT }}'
 [task.template-options]
-expect-equals = 'Chomp Chomp  Chomp  $NOREPLACE MM'
+expect-equals = 'Chomp CH Chomp CH  Chomp CH  $NOREPLACE CH'
 
 # -- Test --
 [[task]]


### PR DESCRIPTION
This ordering fix makes it easier for global default environment variables to be replaced into environment variables on tasks.