### PR TITLE
feat: dot reporter, fixes

### DIFF
--- a/src/chompfile.rs
+++ b/src/chompfile.rs
@@ -29,6 +29,7 @@ pub enum ChompEngine {
 #[serde(rename_all = "kebab-case")]
 pub enum TaskDisplay {
     None,
+    Dot,
     InitStatus,
     StatusOnly,
     InitOnly,

--- a/src/engines/mod.rs
+++ b/src/engines/mod.rs
@@ -263,7 +263,7 @@ impl<'a> CmdPool<'a> {
                 }
                 // any leftover unbatched just get batched
                 for cmd in batch {
-                    if this.exec_cnt + 1 == this.pool_size {
+                    if this.exec_cnt == this.pool_size {
                         break;
                     }
                     this.batching.remove(&cmd.id);

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ mod task;
 
 use std::path::PathBuf;
 
-const CHOMP_CORE: &str = "https://ga.jspm.io/npm:@chompbuild/extensions@0.1.8/";
+const CHOMP_CORE: &str = "https://ga.jspm.io/npm:@chompbuild/extensions@0.1.9/";
 
 const CHOMP_INIT: &str = r#"version = 0.1
 


### PR DESCRIPTION
This adds a new `display = 'dot'` task output, useful for tests, for example with:

```toml
[[task]]
name = 'test:#'
serial = true
deps = ['test/#.test.js']
display = 'dot'
stdio = 'stderr-only'
run = 'node $DEP'
```

This also fixes the `-j` flag which was off-by-one, and updates the extensions.