### PR TITLE
feat: permit extension task ejection

### DIFF
--- a/src/engines/mod.rs
+++ b/src/engines/mod.rs
@@ -18,6 +18,7 @@ mod cmd;
 mod deno;
 mod node;
 
+use std::path::Path;
 use crate::chompfile::ChompEngine;
 use crate::chompfile::TaskStdio;
 use crate::engines::deno::deno_runner;
@@ -40,6 +41,7 @@ use std::time::Duration;
 use std::time::Instant;
 use tokio::process::Child;
 use tokio::time::sleep;
+use tokio::fs;
 
 pub fn replace_env_vars_static(arg: &str, env: &BTreeMap<String, String>) -> String {
     let mut out_arg = String::new();
@@ -259,7 +261,7 @@ impl<'a> CmdPool<'a> {
                     this.execs.get_mut(&exec_num).unwrap().cmd.ids.push(cmd_num);
                 }
                 for cmd in batched.drain(..) {
-                    this.new_exec(cmd);
+                    this.new_exec(cmd).await;
                 }
                 // any leftover unbatched just get batched
                 for cmd in batch {
@@ -275,8 +277,9 @@ impl<'a> CmdPool<'a> {
                         env: cmd.env.clone(),
                         stdio: Some(cmd.stdio.clone()),
                         ids: vec![cmd.id],
-                    });
+                    }).await;
                 }
+
                 this.batch_future = None;
                 Ok(())
             }
@@ -285,7 +288,7 @@ impl<'a> CmdPool<'a> {
         );
     }
 
-    fn new_exec(&mut self, mut cmd: BatchCmd) {
+    async fn new_exec(&mut self, mut cmd: BatchCmd) {
         let debug = self.debug;
 
         let exec_num = self.exec_num;
@@ -300,6 +303,15 @@ impl<'a> CmdPool<'a> {
             }
             for target in &cmd.targets {
                 targets.push(target.to_string());
+            }
+        }
+
+        // create directories for all batched targets
+        // we do this here late so that mtime checking isn't affected by this process
+        for target in &targets {
+            let target_path = Path::new(target);
+            if let Some(parent) = target_path.parent() {
+                fs::create_dir_all(parent).await.unwrap();
             }
         }
 

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -275,7 +275,7 @@ impl ExtensionEnvironment {
         self.has_extensions = true;
         {
             let mut handle_scope = self.handle_scope();
-            let code = v8::String::new(&mut handle_scope, extension_source).unwrap();
+            let code = v8::String::new(&mut handle_scope, &format!("{{{}}}", extension_source)).unwrap();
             let tc_scope = &mut v8::TryCatch::new(&mut handle_scope);
             let resource_name = v8::String::new(tc_scope, &filename).unwrap().into();
             let source_map = v8::String::new(tc_scope, "").unwrap().into();

--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -29,9 +29,14 @@ fn chomp_cache_dir() -> PathBuf {
     path
 }
 
-pub async fn clear_cache() -> Result<()> {
-    fs::remove_dir_all(chomp_cache_dir()).await?;
-    Ok(())
+pub async fn clear_cache() -> std::io::Result<()> {
+    match fs::remove_dir_all(chomp_cache_dir()).await {
+        Ok(()) => Ok(()),
+        Err(e) => match e.kind() {
+            std::io::ErrorKind::NotFound => Ok(()),
+            _ => Err(e)
+        }
+    }
 }
 
 pub async fn prep_cache() -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -383,12 +383,36 @@ async fn main() -> Result<()> {
         || matches.is_present("import_scripts")
     {
         if matches.is_present("eject_templates") {
-            let (has_templates, template_tasks) =
+            let (mut has_templates, mut template_tasks) =
                 expand_template_tasks(&chompfile, &mut extension_env)?;
-            chompfile.task = template_tasks;
+            chompfile.task = Vec::new();
+            for task in extension_env.get_tasks().drain(..) {
+                has_templates = true;
+                chompfile.task.push(ChompTaskMaybeTemplated {
+                    target: task.target,
+                    targets: task.targets,
+                    args: task.args,
+                    cwd: task.cwd,
+                    dep: task.dep,
+                    deps: task.deps,
+                    display: task.display,
+                    engine: task.engine,
+                    env: task.env.unwrap_or_default(),
+                    env_default: task.env_default.unwrap_or_default(),
+                    env_replace: task.env_replace,
+                    invalidation: task.invalidation,
+                    run: task.run,
+                    name: task.name,
+                    serial: task.serial,
+                    stdio: task.stdio,
+                    template: task.template,
+                    template_options: task.template_options
+                });
+            }
+            chompfile.task.append(&mut template_tasks);
             if !has_templates {
                 return Err(anyhow!(
-                    "\x1b[1m{}\x1b[0m has no template usage to eject",
+                    "\x1b[1m{}\x1b[0m has no templates to eject",
                     cfg_file.to_str().unwrap()
                 ));
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -249,8 +249,11 @@ async fn main() -> Result<()> {
     assert!(env::set_current_dir(&cwd).is_ok());
 
     if matches.is_present("clear_cache") {
-        println!("Clearing URL extension cache...");
         http_client::clear_cache().await?;
+        println!("\x1b[1;32m√\x1b[0m Cleared remote URL extension cache.");
+        if targets.len() == 0 {
+            return Ok(());
+        }
     }
 
     init_js_platform();
@@ -438,7 +441,6 @@ async fn main() -> Result<()> {
                     }
                 }
             }
-            return Ok(());
         } else {
             let mut script_tasks = 0;
             if matches.is_present("import_scripts") {
@@ -512,9 +514,9 @@ async fn main() -> Result<()> {
                     if created { "created" } else { "updated" }
                 );
             }
-            if matches.is_present("eject_templates") || targets.len() == 0 {
-                return Ok(());
-            }
+        }
+        if matches.is_present("eject_templates") || targets.len() == 0 {
+            return Ok(());
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ mod task;
 
 use std::path::PathBuf;
 
-const CHOMP_CORE: &str = "https://ga.jspm.io/npm:@chompbuild/extensions@0.1.10/";
+const CHOMP_CORE: &str = "https://ga.jspm.io/npm:@chompbuild/extensions@0.1.11/";
 
 const CHOMP_INIT: &str = r#"version = 0.1
 

--- a/src/task.rs
+++ b/src/task.rs
@@ -320,12 +320,7 @@ pub async fn check_target_mtimes(targets: Vec<String>, default_latest: bool) -> 
                             .unwrap(),
                     ),
                     Err(e) => match e.kind() {
-                        NotFound => {
-                            if let Some(parent) = target_path.parent() {
-                                fs::create_dir_all(parent).await.unwrap();
-                            }
-                            None
-                        }
+                        NotFound => None,
                         _ => panic!("Unknown file error"),
                     },
                 }

--- a/src/task.rs
+++ b/src/task.rs
@@ -320,7 +320,12 @@ pub async fn check_target_mtimes(targets: Vec<String>, default_latest: bool) -> 
                             .unwrap(),
                     ),
                     Err(e) => match e.kind() {
-                        NotFound => None,
+                        NotFound => {
+                            if let Some(parent) = target_path.parent() {
+                                fs::create_dir_all(parent).await.unwrap();
+                            }
+                            None
+                        },
                         _ => panic!("Unknown file error"),
                     },
                 }


### PR DESCRIPTION
This adds support for ejection of static `Chomp.addTask` declarations in extensions, specifically in the npm workflow to eject the `npm:install` task.

Also resolves https://github.com/guybedford/chomp/issues/75.