### PR TITLE
fix: Node.js engine on latest

### DIFF
--- a/src/engines/node.rs
+++ b/src/engines/node.rs
@@ -20,34 +20,28 @@ use crate::engines::CmdPool;
 use crate::engines::Exec;
 use crate::engines::{BatchCmd, ExecState};
 use futures::future::FutureExt;
-use std::env;
 use std::time::Instant;
-use tokio::fs;
-use uuid::Uuid;
+use percent_encoding::{percent_encode, NON_ALPHANUMERIC};
 
 // Custom node loader to mimic current working directory despite loading from a tmp file
-const NODE_CMD: &str = "node --no-warnings --loader \"data:text/javascript,import{readFileSync}from'fs';export function resolve(u,c,d){if(u.endsWith('[cm]'))return{url:u,format:'module'};return d(u,c);}export function load(u,c,d){if(u.endsWith('[cm]'))return{source:readFileSync(process.env.CHOMP_MAIN),format:'module'};return d(u,c)}export{load as getFormat,load as getSource}\" [cm]";
+const NODE_LOADER: &str = "let s;export function resolve(u,c,d){if(!c.parentURL){const i=u.indexOf('data:text/javascript,');s=decodeURIComponent(decodeURIComponent(u.slice(i+21)));return{url:`${u.slice(0,i)}/[cm]`,format:'module'}}return d(u,c)}export function load(u,c,d){if(u.endsWith('[cm]'))return{source:s,format:'module'};return d(u,c)}export{load as getFormat,load as getSource}";
 
 pub fn node_runner(cmd_pool: &mut CmdPool, mut cmd: BatchCmd, targets: Vec<String>) {
   let start_time = Instant::now();
-  let uuid = Uuid::new_v4();
-  let mut tmp_file = env::temp_dir();
-  tmp_file.push(&format!("{}.mjs", uuid.to_simple().to_string()));
-  let tmp_file2 = tmp_file.clone();
-  cmd.env.insert(
-    "CHOMP_MAIN".to_string(),
-    tmp_file.to_str().unwrap().to_string(),
-  );
   cmd.env.insert(
     "CHOMP_PATH".to_string(),
     std::env::args().next().unwrap().to_string(),
   );
   let targets = targets.clone();
   // On posix, command starts executing before we wait on it!
-  std::fs::write(tmp_file, cmd.run.to_string()).expect("unable to write temporary file");
-  cmd.run = NODE_CMD.to_string();
+  cmd.run = format!(
+    "node --no-warnings --loader data:text/javascript,{} data:text/javascript,{}",
+    percent_encode(NODE_LOADER.as_bytes(), NON_ALPHANUMERIC).to_string(),
+    percent_encode(cmd.run.as_bytes(), NON_ALPHANUMERIC).to_string()
+  );
   let echo = cmd.echo;
   cmd.echo = false;
+  let run_clone = if echo { Some(cmd.run.clone()) } else { None };
   let exec_num = cmd_pool.exec_num;
   cmd_pool.exec_cnt = cmd_pool.exec_cnt + 1;
   let pool = cmd_pool as *mut CmdPool;
@@ -63,7 +57,7 @@ pub fn node_runner(cmd_pool: &mut CmdPool, mut cmd: BatchCmd, targets: Vec<Strin
       return None;
     }
     if echo {
-      println!("<Node.js exec>");
+      println!("{}", run_clone.as_ref().unwrap());
     }
     exec.state = match exec.child.as_mut().unwrap().wait().await {
       Ok(status) => {
@@ -79,9 +73,6 @@ pub fn node_runner(cmd_pool: &mut CmdPool, mut cmd: BatchCmd, targets: Vec<Strin
       },
     };
     cmd_pool.exec_cnt = cmd_pool.exec_cnt - 1;
-    fs::remove_file(&tmp_file2)
-      .await
-      .expect("unable to cleanup tmp file");
     let end_time = Instant::now();
     // finally we verify that the targets exist
     let mtime = check_target_mtimes(targets, true).await;


### PR DESCRIPTION
The Node.js engine was no longer working on the latest Node.js since the data: URL loader doesn't have access to the `import 'fs'` anymore for security in the HTTPs imports PR.

This updates the loader to work without needing any extra files present, which also usefully makes the `echo = true` output for Node.js tasks, while percent encoded, the actual correct execution which can be copied and pasted to run the task locally if desired, which seems a useful property.