### PR TITLE
fix: stop commands on error

### DIFF
--- a/src/chompfile.rs
+++ b/src/chompfile.rs
@@ -123,6 +123,7 @@ pub enum ValidationCheck {
     OkTargets,
     TargetsOnly,
     OkOnly,
+    NotOk,
     None,
 }
 

--- a/src/engines/cmd.rs
+++ b/src/engines/cmd.rs
@@ -364,6 +364,7 @@ pub fn create_cmd(
         command.env(name, value);
     }
     command.current_dir(cwd);
+    command.arg("-e");
     command.arg("-c");
     command.arg(&run);
     set_cmd_stdio(&mut command, batch_cmd.stdio.unwrap_or_default());

--- a/src/engines/cmd.rs
+++ b/src/engines/cmd.rs
@@ -241,7 +241,7 @@ pub fn create_cmd(
         command.arg("-NonInteractive");
         command.arg("-NoLogo");
         // ensure file operations use UTF8
-        let mut run_str = String::from("$PSDefaultParameterValues['Out-File:Encoding']='utf8';");
+        let mut run_str = String::from("$PSDefaultParameterValues['Out-File:Encoding']='utf8';$ErrorActionPreference='Stop';");
         // we also set _custom_ variables as local variables for easy substitution
         for (name, value) in &batch_cmd.env {
             run_str.push_str(&format!("${}='{}';", name, value.replace("'", "''")));

--- a/src/task.rs
+++ b/src/task.rs
@@ -1397,13 +1397,16 @@ impl<'a> Runner<'a> {
                                 node_num,
                                 mtime,
                                 Some(cmd_time),
-                                matches!(
+                                matches!(validation, ValidationCheck::NotOk) || matches!(
                                     validation,
                                     ValidationCheck::TargetsOnly | ValidationCheck::OkTargets
                                 ) && mtime.is_none(),
                             );
                         }
                         ExecState::Failed => match validation {
+                            ValidationCheck::NotOk => {
+                                self.mark_complete(node_num, mtime, Some(cmd_time), false)
+                            }
                             ValidationCheck::OkOnly | ValidationCheck::OkTargets => {
                                 self.mark_complete(node_num, mtime, Some(cmd_time), true)
                             }

--- a/src/task.rs
+++ b/src/task.rs
@@ -1920,7 +1920,7 @@ impl<'a> Runner<'a> {
                         return Err(anyhow!(
                             "Task {} defines a {} interpolate target {} but with a {} interpolation dep. Dependency interpolation must use a '{}' interpolate to match.",
                             &display_name,
-                            if double_interpolate { "double" } else { "single "},
+                            if double_interpolate { "double" } else { "single" },
                             is_interpolate.unwrap(),
                             if double_interpolate { "single" } else { "double" },
                             if double_interpolate { "##" } else { "#" }

--- a/src/task.rs
+++ b/src/task.rs
@@ -1947,7 +1947,7 @@ impl<'a> Runner<'a> {
         glob_target.push_str(&dep[0..interpolate_idx]);
         if double {
             if !glob_target.ends_with('/') && !glob_target.ends_with('\\') {
-                return Err(anyhow!("Unable to apply deep globbing to interpolate {}. Deep globbing interpolates are only supported for full paths with the '##' in a separator position.", &dep));
+                return Err(anyhow!("Unable to apply deep globbing to interpolate {}. Deep globbing interpolates are only supported for full paths with '##' immediately following a separator position.", &dep));
             }
             glob_target.push_str("(**/*)");
         } else {

--- a/test/chompfile.toml
+++ b/test/chompfile.toml
@@ -165,3 +165,12 @@ run = 'echo "$DEPS" > output/deps.txt'
 template = 'assert'
 [task.template-options]
 expect-match = 'fixtures/src/(app|dep)\.ts:fixtures/src/(app|dep)\.ts:output/lib/app.js:output/lib/dep.js'
+
+# -- Test --
+[[task]]
+name = 'test7'
+validation = 'not-ok'
+run = '''
+  FAIL
+  echo "THIS SHOULD NOT LOG"
+'''

--- a/test/chompfile.toml
+++ b/test/chompfile.toml
@@ -17,7 +17,8 @@ deps = ['test:clean', 'test:run']
 name = 'test:clean'
 display = 'status-only'
 stdio = 'none'
-run = 'rm -r output ; echo recover'
+validation = 'none'
+run = 'rm -r output'
 
 [[task]]
 name = 'test:run'


### PR DESCRIPTION
This ensures for multi-step scripts in powershell or sh will stop on the first error strictly instead of proceeding, and ensuring the exit code is an error.

Resolves https://github.com/guybedford/chomp/issues/98.