### PR TITLE
Update cmd.rs execution context from "sh" to "bash"

### DIFF
--- a/src/engines/cmd.rs
+++ b/src/engines/cmd.rs
@@ -358,7 +358,7 @@ pub fn create_cmd(
         }
     }
 
-    let mut command = Command::new("sh");
+    let mut command = Command::new("bash");
     command.env("PATH", path);
     for (name, value) in &batch_cmd.env {
         command.env(name, value);


### PR DESCRIPTION
Commands in a linux environment were being executed via `sh`, rather than via `bash`. I found this because I was trying to `source env.sh`, which only works in the context of bash