### PR TITLE
fix: auto chompfile.toml for directories

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -204,11 +204,11 @@ async fn main() -> Result<()> {
 
     let mut created = false;
     let chompfile_source = {
-        let is_file: bool = match fs::metadata(&cfg_file) {
-            Ok(meta) => !meta.is_dir(),
+        let is_dir: bool = match fs::metadata(&cfg_file) {
+            Ok(meta) => meta.is_dir(),
             Err(_) => false
         };
-        if !is_file {
+        if is_dir {
             cfg_file.push("chompfile.toml");
         }
         match fs::read_to_string(&cfg_file) {


### PR DESCRIPTION
This fixes a bug from the auto-directory handling for `chomp -c ./dir` stopping `chomp --init -c x.toml` style workflows from working.