### PR TITLE
fix: interpolation edge cases

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ mod server;
 
 use std::path::PathBuf;
 
-const CHOMP_CORE: &str = "https://ga.jspm.io/npm:@chompbuild/extensions@0.1.22/";
+const CHOMP_CORE: &str = "https://ga.jspm.io/npm:@chompbuild/extensions@0.1.24/";
 
 const CHOMP_INIT: &str = r#"version = 0.1
 


### PR DESCRIPTION
This fixes a number of interpolation edge cases:

* When the path matching an interpolation was shorter than the interpolation pattern (ie when using `##` with a single character file), there was an integer overflow which is now fixed.
* When the target of an interpolation was used to drive another interpolation in turn, that further interpolation wouldn't trigger until the second run of the build. This fixes that by handling the interpolation expansion as itself driving further interpolations as necessary. Ideally this should fully integrate into all globbed dependencies, and a comment noting this has been added.
* When the target of an interpolation also matches the dependency pattern of that same interpolation, this results in recursion. To fix this, interpolation dependencies which in turn match their own target pattern are explicitly excluded. This function has been separated as `check_interpolate_exclude` as a function on the path and task which could extend to further ignores in future is a `task.interpolation-ignore` field supporting arbitrary paths. This resolves https://github.com/guybedford/chomp/issues/133.