### PR TITLE
feat: watch-invalidation option

### DIFF
--- a/src/chompfile.rs
+++ b/src/chompfile.rs
@@ -140,6 +140,19 @@ impl Default for InvalidationCheck {
     }
 }
 
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Copy)]
+#[serde(rename_all = "kebab-case")]
+pub enum WatchInvalidation {
+    RestartRunning,
+    SkipRunning,
+}
+
+impl Default for WatchInvalidation {
+    fn default() -> Self {
+        WatchInvalidation::RestartRunning
+    }
+}
+
 #[derive(Debug, Serialize, PartialEq, Deserialize, Clone)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub struct ChompTaskMaybeTemplated {
@@ -150,6 +163,7 @@ pub struct ChompTaskMaybeTemplated {
     pub deps: Option<Vec<String>>,
     pub args: Option<Vec<String>>,
     pub serial: Option<bool>,
+    pub watch_invalidation: Option<WatchInvalidation>,
     pub invalidation: Option<InvalidationCheck>,
     pub validation: Option<ValidationCheck>,
     pub display: Option<TaskDisplay>,
@@ -195,6 +209,7 @@ impl ChompTaskMaybeTemplated {
             stdio: None,
             template: None,
             template_options: None,
+            watch_invalidation: None,
         }
     }
     pub fn targets_vec(&self) -> Result<Vec<String>> {
@@ -245,6 +260,7 @@ pub struct ChompTaskMaybeTemplatedJs {
     pub serial: Option<bool>,
     pub invalidation: Option<InvalidationCheck>,
     pub validation: Option<ValidationCheck>,
+    pub watch_invalidation: Option<WatchInvalidation>,
     pub display: Option<TaskDisplay>,
     pub stdio: Option<TaskStdio>,
     pub engine: Option<ChompEngine>,
@@ -281,6 +297,7 @@ impl Into<ChompTaskMaybeTemplated> for ChompTaskMaybeTemplatedJs {
             engine: self.engine,
             template: self.template,
             template_options: self.template_options,
+            watch_invalidation: self.watch_invalidation,
         }
     }
 }

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -156,6 +156,7 @@ pub fn expand_template_tasks(
             engine: task.engine,
             template: None,
             template_options: task.template_options,
+            watch_invalidation: task.watch_invalidation,
         };
         let mut template_tasks: Vec<ChompTaskMaybeTemplatedJs> =
             extension_env.run_template(&template, &js_task)?;


### PR DESCRIPTION
Adds a new `watch-invalidation` configuration option which allows customizing how invalidations for long-running tasks should work.

The default is the existing behaviour of terminating and re-running the currently running task, with a new option, `watch-invalidation: 'skip-running'` which skips termination and re-execution if the task is already running.