### PR TITLE
Typo in readme

### DIFF
--- a/docs/task.md
+++ b/docs/task.md
@@ -6,7 +6,7 @@ _chompfile.toml_
 ```toml
 version = 0.1
 
-default_task = 'echo'
+default-task = 'echo'
 
 [[task]]
 name = 'echo'


### PR DESCRIPTION
Changed `default_task` to `default-task`, since the latter works with chomp v0.2.6