### PR TITLE
fix: split paths with semicolon

### DIFF
--- a/src/task.rs
+++ b/src/task.rs
@@ -1100,7 +1100,7 @@ impl<'a> Runner<'a> {
                 .unwrap()
                 .to_string()
         }).collect::<Vec<String>>();
-        env.insert("DEPS".to_string(), relative_deps.join(":"));
+        env.insert("DEPS".to_string(), relative_deps.join(";"));
 
         if task.chomp_task.args.is_some() {
             for arg in task.chomp_task.args.as_ref().unwrap() {

--- a/test/chompfile.toml
+++ b/test/chompfile.toml
@@ -164,7 +164,7 @@ deps = ['./fixtures/src/**/*.ts', 'build:swc']
 run = 'echo "$DEPS" > output/deps.txt'
 template = 'assert'
 [task.template-options]
-expect-match = 'fixtures/src/app.ts:fixtures/src/dep.ts:output/lib/app.js:output/lib/dep.js'
+expect-match = 'fixtures/src/app.ts;fixtures/src/dep.ts;output/lib/app.js;output/lib/dep.js'
 
 # -- Test --
 [[task]]


### PR DESCRIPTION
This was discussed in #140 for better platform compatibility.