### PR TITLE
feat: set default task to build

### DIFF
--- a/docs/chompfile.md
+++ b/docs/chompfile.md
@@ -16,14 +16,12 @@ chompfile.toml
 ```toml
 version = 0.1
 
-default-task = 'build'
-
 [[task]]
 name = 'build'
 run = 'echo "Chomp Chomp"'
 ```
 
-In the command line, type:
+In the command line, type `chomp build` or just `chomp` (_"build"_ is the default task when none is given):
 
 ```sh
 $ chomp

--- a/docs/task.md
+++ b/docs/task.md
@@ -6,8 +6,6 @@ _chompfile.toml_
 ```toml
 version = 0.1
 
-default-task = 'echo'
-
 [[task]]
 name = 'echo'
 run = 'echo "Chomp"'
@@ -15,7 +13,7 @@ run = 'echo "Chomp"'
 
 _<div style="text-align: center">An example Chompfile.</div>_
 
-Running `chomp echo` or `chomp` will output the echo command.
+Running `chomp echo` will output the echo command.
 
 ## Task API
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -543,10 +543,7 @@ async fn main() -> Result<()> {
     }
 
     let targets = if targets.len() == 0 && use_default_target {
-        match &chompfile.default_task {
-            Some(default_task) => vec![default_task.clone()],
-            None => return Err(anyhow!("No default task provided. Set:\x1b[36m\n\n  default-task = '[taskname]'\n\n\x1b[0min the \x1b[1mchompfile.toml\x1b[0m to configure a default build task.")),
-        }
+        vec![chompfile.default_task.to_owned().unwrap_or(String::from("build"))]
     } else {
         targets
     };


### PR DESCRIPTION
This makes the `default-task` always `"build"`. I've found having `chomp` just work in all Chomp projects to get things running is a pretty good pattern to follow usually.