### PR TITLE
fix: execution triangle mac support

### DIFF
--- a/src/engines/mod.rs
+++ b/src/engines/mod.rs
@@ -299,7 +299,7 @@ impl<'a> CmdPool<'a> {
             let cmd = &self.cmds[&id];
             self.cmd_execs.insert(*id, exec_num);
             if let Some(name) = &cmd.name {
-                println!("\x1b[1m🞂 {}\x1b[0m", name);
+                println!("\x1b[1m▶ {}\x1b[0m", name);
             }
             for target in &cmd.targets {
                 let target_path = Path::new(target);


### PR DESCRIPTION
Fixes the build start character to be compatible on macs.