### PR TITLE
fix: path lookups chompfile-cwd relative

### DIFF
--- a/docs/task.md
+++ b/docs/task.md
@@ -112,7 +112,7 @@ run = 'swc $DEP -o $TARGET --source-maps'
 
 _<div style="text-align: center">SWC task compiling the TypeScript module `src/app.ts` into a JS module `lib/app.js`, and supporting configuration in an `.swcrc` file.</div>_
 
-The above works without having to reference the full `node_modules/.bin/swc` command prefix since `node_modules/.bin` is automatically included in the Chomp spawned `PATH`.
+The above works without having to reference the full `node_modules/.bin/swc` command prefix since `node_modules/.bin` is automatically included in the Chomp spawned `PATH`, relative to the Chompfile itself.
 
 ### Environment Variables
 

--- a/src/chompfile.rs
+++ b/src/chompfile.rs
@@ -18,7 +18,10 @@ use anyhow::Result;
 use directories::UserDirs;
 use regex::{Captures, Regex};
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, path::{Component, Path, PathBuf}};
+use std::{
+    collections::HashMap,
+    path::{Component, Path, PathBuf},
+};
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, Hash, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
@@ -314,9 +317,7 @@ impl Into<ChompTaskMaybeTemplated> for ChompTaskMaybeTemplatedJs {
 }
 
 pub fn resolve_path(target: &str, cwd: &str) -> String {
-    path_from(cwd, target)
-        .to_string_lossy()
-        .replace('\\', "/")
+    path_from(cwd, target).to_string_lossy().replace('\\', "/")
 }
 /// https://stackoverflow.com/questions/68231306/stdfscanonicalize-for-files-that-dont-exist
 /// build a usable path from a user input which may be absolute

--- a/src/engines/cmd.rs
+++ b/src/engines/cmd.rs
@@ -100,7 +100,12 @@ fn set_cmd_stdio(command: &mut Command, stdio: TaskStdio) {
 }
 
 #[cfg(target_os = "windows")]
-pub fn create_cmd(cwd: &String, batch_cmd: &BatchCmd, fastpath_fallback: bool) -> Option<Child> {
+pub fn create_cmd(
+    cwd: &str,
+    path: &str,
+    batch_cmd: &BatchCmd,
+    fastpath_fallback: bool,
+) -> Option<Child> {
     let run = batch_cmd.run.trim();
     lazy_static! {
         static ref CMD: Regex = Regex::new(
@@ -123,14 +128,6 @@ pub fn create_cmd(cwd: &String, batch_cmd: &BatchCmd, fastpath_fallback: bool) -
         )
         .unwrap();
     }
-    let mut path: String = env::var("PATH").unwrap_or_default();
-    if path.len() > 0 && !path.ends_with(';') {
-        path += ";";
-    }
-    path.push_str(cwd);
-    path += "\\.bin;";
-    path.push_str(cwd);
-    path += "\\node_modules\\.bin;";
     if batch_cmd.echo {
         println!("{}", &run);
     }
@@ -263,7 +260,12 @@ pub fn create_cmd(cwd: &String, batch_cmd: &BatchCmd, fastpath_fallback: bool) -
 }
 
 #[cfg(not(target_os = "windows"))]
-pub fn create_cmd(cwd: &String, batch_cmd: &BatchCmd, fastpath_fallback: bool) -> Option<Child> {
+pub fn create_cmd(
+    cwd: &str,
+    path: &str,
+    batch_cmd: &BatchCmd,
+    fastpath_fallback: bool,
+) -> Option<Child> {
     let run = batch_cmd.run.trim();
     lazy_static! {
         static ref CMD: Regex = Regex::new(
@@ -286,14 +288,6 @@ pub fn create_cmd(cwd: &String, batch_cmd: &BatchCmd, fastpath_fallback: bool) -
         )
         .unwrap();
     }
-    let mut path: String = env::var("PATH").unwrap_or_default();
-    if path.len() > 0 && !path.ends_with(':') {
-        path += ":";
-    }
-    path.push_str(cwd);
-    path += "/.bin:";
-    path.push_str(cwd);
-    path += "/node_modules/.bin";
 
     if batch_cmd.echo {
         println!("{}", run);

--- a/src/engines/deno.rs
+++ b/src/engines/deno.rs
@@ -49,7 +49,12 @@ pub fn deno_runner(cmd_pool: &mut CmdPool, mut cmd: BatchCmd, targets: Vec<Strin
     let pool = cmd_pool as *mut CmdPool;
     let echo = cmd.echo;
     cmd.echo = false;
-    let child = create_cmd(cmd.cwd.as_ref().unwrap_or(&cmd_pool.cwd), &cmd, false);
+    let child = create_cmd(
+        cmd.cwd.as_ref().unwrap_or(&cmd_pool.cwd),
+        &cmd_pool.path,
+        &cmd,
+        false,
+    );
     let future = async move {
         let cmd_pool = unsafe { &mut *pool };
         let mut exec = &mut cmd_pool.execs.get_mut(&exec_num).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,14 +92,14 @@ async fn main() -> Result<()> {
             Arg::new("server-root")
                 .short('R')
                 .long("server-root")
-                .help("Server root path")
+                .help("Server root path"),
         )
         .arg(
             Arg::new("port")
                 .short('p')
                 .long("port")
                 .value_name("PORT")
-                .help("Custom port to serve")
+                .help("Custom port to serve"),
         )
         .arg(
             Arg::new("jobs")
@@ -107,7 +107,7 @@ async fn main() -> Result<()> {
                 .long("jobs")
                 .value_name("N")
                 .value_parser(clap::value_parser!(usize))
-                .help("Maximum number of jobs to run in parallel")
+                .help("Maximum number of jobs to run in parallel"),
         )
         .arg(
             Arg::new("config")
@@ -115,7 +115,7 @@ async fn main() -> Result<()> {
                 .long("config")
                 .value_name("CONFIG")
                 .default_value("chompfile.toml")
-                .help("Custom chompfile path")
+                .help("Custom chompfile path"),
         )
         .arg(
             Arg::new("list")
@@ -176,14 +176,14 @@ async fn main() -> Result<()> {
             Arg::new("target")
                 .value_name("TARGET")
                 .help("Generate a target or list of targets")
-                .action(ArgAction::Append)
+                .action(ArgAction::Append),
         )
         .arg(
             Arg::new("arg")
                 .last(true)
                 .value_name("ARGS")
                 .help("Custom task args")
-                .action(ArgAction::Append)
+                .action(ArgAction::Append),
         )
         .get_matches();
 
@@ -511,9 +511,7 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
-    if matches.get_flag("format")
-        || matches.get_flag("eject_templates")
-        || matches.get_flag("init")
+    if matches.get_flag("format") || matches.get_flag("eject_templates") || matches.get_flag("init")
     {
         use_default_target = false;
         if matches.get_flag("eject_templates") {
@@ -546,7 +544,10 @@ async fn main() -> Result<()> {
     }
 
     let targets = if targets.len() == 0 && use_default_target {
-        vec![chompfile.default_task.to_owned().unwrap_or(String::from("build"))]
+        vec![chompfile
+            .default_task
+            .to_owned()
+            .unwrap_or(String::from("build"))]
     } else {
         targets
     };

--- a/src/task.rs
+++ b/src/task.rs
@@ -14,7 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use crate::chompfile::{ChompTaskMaybeTemplated, TaskDisplay, ValidationCheck, WatchInvalidation, Chompfile, InvalidationCheck, resolve_path};
+use crate::chompfile::{
+    resolve_path, ChompTaskMaybeTemplated, Chompfile, InvalidationCheck, TaskDisplay,
+    ValidationCheck, WatchInvalidation,
+};
 use crate::engines::CmdPool;
 use crate::server::FileEvent;
 use crate::ExtensionEnvironment;
@@ -268,7 +271,11 @@ impl<'a> Job {
             String::from(format!("[task {}]", self.task))
         };
 
-        if skip_relative_path { name } else { relative_path(&name, cwd) }
+        if skip_relative_path {
+            name
+        } else {
+            relative_path(&name, cwd)
+        }
     }
 }
 
@@ -1081,9 +1088,10 @@ impl<'a> Runner<'a> {
         };
         env.insert("DEP".to_string(), relative_dep);
 
-        let mut relative_deps = deps.iter().map(|d| {
-            relative_path(d, &self.cwd)
-        }).collect::<Vec<String>>();
+        let mut relative_deps = deps
+            .iter()
+            .map(|d| relative_path(d, &self.cwd))
+            .collect::<Vec<String>>();
         relative_deps.sort();
         env.insert("DEPS".to_string(), relative_deps.join(":"));
 
@@ -1646,7 +1654,8 @@ impl<'a> Runner<'a> {
                         {
                             interpolate_match = Some((
                                 *job_num,
-                                &resolved_target[interpolate_idx..resolved_target.len() - rhs.len()],
+                                &resolved_target
+                                    [interpolate_idx..resolved_target.len() - rhs.len()],
                             ));
                             if lhs.len() >= interpolate_lhs_match_len
                                 && rhs.len() > interpolate_rhs_match_len
@@ -2290,9 +2299,7 @@ impl<'a> Runner<'a> {
             DebouncedEvent::Remove(path)
             | DebouncedEvent::Create(path)
             | DebouncedEvent::Write(path)
-            | DebouncedEvent::Rename(_, path) => {
-                self.invalidate_path(path, queued, redrives)
-            }
+            | DebouncedEvent::Rename(_, path) => self.invalidate_path(path, queued, redrives),
             DebouncedEvent::Rescan => panic!("Watcher rescan"),
             DebouncedEvent::Error(err, maybe_path) => {
                 panic!("WATCHER ERROR {:?} {:?}", err, maybe_path.clone())
@@ -2342,14 +2349,18 @@ impl<'a> Runner<'a> {
                 None => {
                     return Err(anyhow!(
                         "Task \x1b[1m{}\x1b[0m doesn't take any arguments.",
-                        self.get_job(job_num).unwrap().display_name(&self.tasks, &self.cwd)
+                        self.get_job(job_num)
+                            .unwrap()
+                            .display_name(&self.tasks, &self.cwd)
                     ));
                 }
             };
             if task_args_len < args.len() {
                 return Err(anyhow!(
                     "Task \x1b[1m{}\x1b[0m only takes {} arguments, while {} were provided.",
-                    self.get_job(job_num).unwrap().display_name(&self.tasks, &self.cwd),
+                    self.get_job(job_num)
+                        .unwrap()
+                        .display_name(&self.tasks, &self.cwd),
                     task_args_len,
                     args.len()
                 ));


### PR DESCRIPTION
When setting the `cwd` on a specific task, this was causing the `node_modules/.bin` automatic path inclusion to be relative to that task-specific cwd. Instead we use the Chompfile-level cwd here so that we use a consistent path lookup across all tasks and task-specific cwds do not affect the script pathing.

There could be an argument for mono repo patterns where commands should first be looked up in node_modules folders in sub-packages. I think that this should rather be tackled as any workspace work though in treating the path fallback as being from the workspace to the project here as part of the workspace support.