### PR TITLE
Update Cargo install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Chomp [caches tasks](./docs/task.md#task-caching) based on task dependencies lik
 If you use [Cargo](https://rustup.rs/), run:
 
 ```
-cargo install chompbuild
+cargo install chompbuild --locked
 ```
 
 If you don't use Cargo, run:


### PR DESCRIPTION
Must provide `--locked` for `cargo install` to respect the published `Cargo.lock` otherwise it only considers the `Cargo.toml` entries which, for this project, are all locked to "major" version, not minor or patch. And currently `hyper` and `hyper-tls` do not work with latest.